### PR TITLE
Fix AI tool paths to match npm/native install locations

### DIFF
--- a/guest/home/bin/claude
+++ b/guest/home/bin/claude
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-APP="$(brew --prefix)/bin/claude"
+APP="$HOME/.local/bin/claude"
 if [[ ! -x "$APP" ]]; then
     echo >&2 "Installing claude..."
-    npm install --global --silent @anthropic-ai/claude-code@latest
+    curl -fsSL https://claude.ai/install.sh | sh
 fi
 exec "$APP" --dangerously-skip-permissions "$@"

--- a/guest/home/bin/codex
+++ b/guest/home/bin/codex
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-APP="$(brew --prefix)/bin/codex"
+APP="$HOME/node_modules/bin/codex"
 if [[ ! -x "$APP" ]]; then
     echo >&2 "Installing codex..."
     npm install --global --silent @openai/codex@latest

--- a/guest/home/bin/gemini
+++ b/guest/home/bin/gemini
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-APP="$(brew --prefix)/bin/gemini"
+APP="$HOME/node_modules/bin/gemini"
 if [[ ! -x "$APP" ]]; then
     echo >&2 "Installing gemini..."
     npm install --global --silent @google/gemini-cli


### PR DESCRIPTION
## Summary

- **claude**: Use native installer path (`~/.local/bin/claude`) instead of brew prefix, and switch from npm to official install script (`curl -fsSL https://claude.ai/install.sh`)
- **codex**: Use npm global prefix path (`$HOME/node_modules/bin`) to match `.npmrc` configuration
- **gemini**: Use npm global prefix path (`$HOME/node_modules/bin`) to match `.npmrc` configuration

The previous paths assumed tools would be installed to `$(brew --prefix)/bin`, but:
1. `.npmrc` sets `prefix=${HOME}/node_modules`, so npm global installs go there
2. Claude Code now uses a native installer that installs to `~/.local/bin`

## Test plan

- [ ] Run `clod --rebuild-dst claude` and verify Claude Code launches
- [ ] Run `clod --rebuild-dst codex` and verify Codex launches
- [ ] Run `clod --rebuild-dst gemini` and verify Gemini CLI launches

---

🤖 Generated with [Claude Code](https://claude.ai/code)