### PR TITLE
Generic per-agent extra args via CLODPOD_*_ARGS env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Usage:
     # avoid leaking your passwords there :)
      CLODPOD_PASSWORD='your-password' clod shell
 
+    # Pass extra flags to an agent (e.g. Claude Code remote control)
+    CLODPOD_CLAUDE_ARGS="--remote-control" clod claude
+
     # Stop all clodpod virtual machines
     clod stop
 

--- a/clod
+++ b/clod
@@ -627,7 +627,6 @@ init_db
 NO_GRAPHICS="${NO_GRAPHICS:-}"
 SHOULD_SELECT_PROJECT=true
 ALLOW_SUDO=
-REMOTE_CONTROL=
 
 show_help() {
     echo "Usage: clod [options] command [args...]"
@@ -639,7 +638,6 @@ show_help() {
     echo "  --rebuild-dst        Force rebuild of the final image (update \$HOME)"
     echo "  --allow-sudo         Allow passwordless sudo for clodpod user (rebuilds if setting changed)"
     echo "  --no-allow-sudo      Disallow sudo for clodpod user (rebuilds if setting changed)"
-    echo "  --remote-control     Enable Claude Code remote control (--remote-control flag)"
     echo "  -n|--no-select       Disable interactive project selection"
     echo "  -v, --verbose        Enable verbose output (repeat for more verbosity)"
     echo "  -vv                  Set verbosity level 2"
@@ -697,10 +695,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-allow-sudo)
             ALLOW_SUDO=false
-            shift
-            ;;
-        --remote-control)
-            REMOTE_CONTROL=true
             shift
             ;;
         -n|--no-select)
@@ -1058,4 +1052,11 @@ exec ssh \
     -o UserKnownHostsFile=/dev/null \
     -i "$SSH_KEYFILE_PRIV" \
     "clodpod@$IPADDR" \
-    /usr/bin/env "PROJECT=$PROJECT" "INITIAL_DIR=$INITIAL_DIR" "COMMAND=${COMMAND:-}" "REMOTE_CONTROL=${REMOTE_CONTROL:-}" zsh --login || true
+    /usr/bin/env \
+        "PROJECT=$PROJECT" \
+        "INITIAL_DIR=$INITIAL_DIR" \
+        "COMMAND=${COMMAND:-}" \
+        "CLODPOD_CLAUDE_ARGS=${CLODPOD_CLAUDE_ARGS:-}" \
+        "CLODPOD_CODEX_ARGS=${CLODPOD_CODEX_ARGS:-}" \
+        "CLODPOD_GEMINI_ARGS=${CLODPOD_GEMINI_ARGS:-}" \
+        zsh --login || true

--- a/guest/home/.zshrc
+++ b/guest/home/.zshrc
@@ -104,9 +104,5 @@ fi
 
 # Run specified application
 if [[ "${COMMAND:-}" != "" ]]; then
-    COMMAND_ARGS=()
-    if [[ "${COMMAND:-}" == "claude" ]] && [[ "${REMOTE_CONTROL:-}" == "true" ]]; then
-        COMMAND_ARGS+=("--remote-control")
-    fi
-    exec "$COMMAND" "${COMMAND_ARGS[@]+"${COMMAND_ARGS[@]}"}"
+    exec "$COMMAND"
 fi

--- a/guest/home/README.md
+++ b/guest/home/README.md
@@ -1,4 +1,32 @@
 
+## Per-agent extra arguments
+
+Set these environment variables on the **host** to pass extra flags through to each agent's
+wrapper script inside the VM:
+
+| Variable | Agent | Example |
+|---|---|---|
+| `CLODPOD_CLAUDE_ARGS` | Claude Code | `--remote-control` |
+| `CLODPOD_CODEX_ARGS` | OpenAI Codex | `--model o4-mini` |
+| `CLODPOD_GEMINI_ARGS` | Google Gemini | `--debug` |
+
+Usage:
+
+    # One-off
+    CLODPOD_CLAUDE_ARGS="--remote-control" clod claude
+
+    # Persistent — add to your HOST shell profile (~/.zshrc, ~/.zshenv, etc.)
+    # These are host-side variables; do NOT put them in guest/home/user/.zshrc
+    export CLODPOD_CLAUDE_ARGS="--remote-control"
+    clod claude
+
+The variables are forwarded over SSH and appended to the agent's exec invocation after its
+mandatory flags (e.g. `--dangerously-skip-permissions`) and before any arguments you pass on the
+command line. Word-splitting applies, so multiple flags work fine:
+
+    CLODPOD_CLAUDE_ARGS="--remote-control --debug" clod claude
+
+---
 
 TL;DR:
 

--- a/guest/home/bin/claude
+++ b/guest/home/bin/claude
@@ -6,4 +6,5 @@ if [[ ! -x "$APP" ]]; then
     echo >&2 "Installing claude..."
     curl -fsSL https://claude.ai/install.sh | sh
 fi
-exec "$APP" --dangerously-skip-permissions "$@"
+# shellcheck disable=SC2086
+exec "$APP" --dangerously-skip-permissions ${CLODPOD_CLAUDE_ARGS:-} "$@"

--- a/guest/home/bin/codex
+++ b/guest/home/bin/codex
@@ -6,4 +6,5 @@ if [[ ! -x "$APP" ]]; then
     echo >&2 "Installing codex..."
     npm install --global --silent @openai/codex@latest
 fi
-exec "$APP" --dangerously-bypass-approvals-and-sandbox "$@"
+# shellcheck disable=SC2086
+exec "$APP" --dangerously-bypass-approvals-and-sandbox ${CLODPOD_CODEX_ARGS:-} "$@"

--- a/guest/home/bin/gemini
+++ b/guest/home/bin/gemini
@@ -6,4 +6,5 @@ if [[ ! -x "$APP" ]]; then
     echo >&2 "Installing gemini..."
     npm install --global --silent @google/gemini-cli
 fi
-exec "$APP" --yolo "$@"
+# shellcheck disable=SC2086
+exec "$APP" --yolo ${CLODPOD_GEMINI_ARGS:-} "$@"


### PR DESCRIPTION
## Problem

ClodPod currently has no way to pass extra flags to agents. Useful options like Claude Code's
`--remote-control` are simply inaccessible.

## Solution

Per-agent env vars on the host, forwarded over SSH to each agent's wrapper script:

| Variable | Agent |
|---|---|
| `CLODPOD_CLAUDE_ARGS` | Claude Code |
| `CLODPOD_CODEX_ARGS` | OpenAI Codex |
| `CLODPOD_GEMINI_ARGS` | Google Gemini |

Each wrapper appends its var's value before `"$@"`, so the flags land in the right place.

## Usage

```sh
# One-off
CLODPOD_CLAUDE_ARGS="--remote-control" clod claude

# Persistent — add to your host ~/.zshrc
export CLODPOD_CLAUDE_ARGS="--remote-control"
```

> Personal note: I don't yet have access to Claude's `--remote-control` feature, but the day
> Anthropic hands me the keys I'll be ready. :tada: