### PR TITLE
Fix OCI cache handling

### DIFF
--- a/clod
+++ b/clod
@@ -956,6 +956,8 @@ fi
 ###############################################################################
 if ! get_vm_exists "$BASE_VM_NAME" ; then
     # Base VM missing — need to download OCI image and build it
+    # NOTE: Changing MACOS_VERSION/MACOS_FLAVOR does not auto-rebuild an existing base.
+    # Use --rebuild-base to force a rebuild after changing the macOS image.
     if ! get_vm_exists "$MACOS_IMAGE" "oci" ; then
         DOWNLOAD_IMAGE=true
         # This is probably the first time install; be more verbose

--- a/clod
+++ b/clod
@@ -1062,6 +1062,10 @@ if [[ "${REBUILD_BASE:-}" != "" ]]; then
     set_setting "allow_sudo" "$ALLOW_SUDO"
 
     debug "Building $BASE_VM_NAME successful"
+
+    # Prune OCI cache — base VM is built, cache is no longer needed
+    debug "Pruning OCI cache..."
+    tart prune --space-budget=0 2>/dev/null || true
 fi
 
 

--- a/clod
+++ b/clod
@@ -968,6 +968,10 @@ fi
 
 if [[ "${REBUILD_BASE:-}" != "" ]]; then
     REBUILD_DST=true
+    # Ensure OCI image is available when base rebuild is forced (e.g. --rebuild-base, sudo change)
+    if ! get_vm_exists "$MACOS_IMAGE" "oci" ; then
+        DOWNLOAD_IMAGE=true
+    fi
 fi
 
 if [[ "${REBUILD_DST:-}" != "" ]]; then

--- a/clod
+++ b/clod
@@ -954,17 +954,13 @@ fi
 ###############################################################################
 # Download MACOS image
 ###############################################################################
-if ! get_vm_exists "$MACOS_IMAGE" "oci" ; then
-    # Defer downloading the image until after asking to stop
-    # running images to avoid asking questions after a long delay
-    DOWNLOAD_IMAGE=true
-
-    # This is probably the first time install; be more verbose
-    [[ "$VERBOSE" -ge 2 ]] || VERBOSE=2
-
-    # Changing the MACOS image requires rebuild
-    REBUILD_BASE=true
-elif ! get_vm_exists "$BASE_VM_NAME" ; then
+if ! get_vm_exists "$BASE_VM_NAME" ; then
+    # Base VM missing — need to download OCI image and build it
+    if ! get_vm_exists "$MACOS_IMAGE" "oci" ; then
+        DOWNLOAD_IMAGE=true
+        # This is probably the first time install; be more verbose
+        [[ "$VERBOSE" -ge 2 ]] || VERBOSE=2
+    fi
     REBUILD_BASE=true
 elif ! get_vm_exists "$DST_VM_NAME" ; then
     REBUILD_DST=true


### PR DESCRIPTION
If the OCI cache is pruned but the base VM exists, clod unnecessarily
re-downloads ~80 GB and rebuilds the base. This happened to me when
Tart auto-pruned the cache.

Fix: check base VM existence before OCI cache. Also prune OCI cache
after successful base build since it is no longer needed, saving
quite a bit of disk space.