### PR TITLE
Named VM instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Key features:
 - Open multiple AI agents sessions and shell prompts, or use the GUI
 - Headless mode for CI/CD workflows with `--no-graphics`
 - Includes Xcode and common development tools; you can add your own tools too
-- Fast rebuild and relaunch using a two-layer caching system
+- Fast rebuild and relaunch using a three-layer APFS CoW caching system
+- Named VM instances for switching between projects or worktree branches
 
 
 Usage:
@@ -74,6 +75,33 @@ Usage:
     clod add "THIRD PROJECT DIRECTORY"          # also "clod a ..."
     clod remove "FOURTH PROJECT DIRECTORY"      # also "clod rm ..."
     clod list                                   # also "clod l", "clod ls"
+
+
+## Named VM instances
+
+Create named VMs to keep separate environments for different projects
+or worktree branches. Each is a cheap APFS CoW clone of the base VM.
+
+    # Create a named VM with mounted directories
+    clod create myproject --dir project:/path/to/project
+    clod create feature-a --dir work:/path/to/repo/.worktrees/feature-a
+
+    # SSH into a named VM
+    clod shell myproject
+
+    # Only one named VM can run at a time
+    clod shell feature-a    # error if myproject is running
+
+    # Stop and switch
+    clod stop myproject
+    clod shell feature-a
+
+    # List named VMs
+    clod list
+
+    # Clean up
+    clod destroy myproject
+    clod destroy --all
 
 
 ## macOS versions

--- a/clod
+++ b/clod
@@ -1258,6 +1258,20 @@ vm_shell() {
     ssh_into_vm "$vm_name" "$primary_name" "$initial_dir"
 }
 
+vm_stop_instance() {
+    local instance_name="$1"
+    local vm_name
+
+    vm_name="$(vm_get_instance_vm_name "$instance_name")"
+    [[ -n "$vm_name" ]] || abort "Error: instance not found ($instance_name)"
+
+    if ! get_vm_exists "$vm_name"; then
+        return 0
+    fi
+
+    stop_vm "$vm_name"
+}
+
 show_version() {
     echo "clod version $VERSION"
     exit 0
@@ -1474,7 +1488,11 @@ case "${1:-}" in
         COMMAND=start
         ;;
     stop)
-        stop_all_vms
+        if [[ -n "${2:-}" ]]; then
+            vm_stop_instance "$2"
+        else
+            stop_all_vms
+        fi
         exit 0
         ;;
     add|a)

--- a/clod
+++ b/clod
@@ -351,6 +351,25 @@ UPDATE projects SET active = 1;
 EOF
 }
 
+vm_run () {
+    local vm_name="$1"
+    shift
+
+    debug "Running $vm_name"
+
+    local args=("$@")
+    [[ "${NO_GRAPHICS:-}" == "" ]] || args+=("--no-graphics")
+
+    if [[ "${#args[@]}" -gt 0 ]]; then
+        tart run \
+            "${args[@]}" \
+            "$vm_name" </dev/null &>/dev/null & disown
+    else
+        tart run "$vm_name" </dev/null &>/dev/null & disown
+    fi
+    wait_vm_running "$vm_name"
+}
+
 stop_vm () {
     local vm_name="$1"
     if [[ "$(get_vm_state "$vm_name")" != "stopped" ]]; then

--- a/clod
+++ b/clod
@@ -481,6 +481,57 @@ SELECT vm_name FROM instances WHERE name = '$(sql_escape "$instance_name")' LIMI
 EOF
 }
 
+vm_get_instance_count() {
+    sqlite3 "$DB_FILE" <<EOF
+SELECT COUNT(*) FROM instances;
+EOF
+}
+
+vm_get_instance_names() {
+    sqlite3 "$DB_FILE" <<EOF
+SELECT name FROM instances ORDER BY created_at DESC, name ASC;
+EOF
+}
+
+vm_get_only_instance_name() {
+    sqlite3 "$DB_FILE" <<EOF
+SELECT name FROM instances ORDER BY created_at DESC, name ASC LIMIT 1;
+EOF
+}
+
+vm_get_instance_dirs() {
+    local instance_name="$1"
+    sqlite3 -separator '|' "$DB_FILE" <<EOF
+SELECT dir_name, dir_path, is_primary
+FROM instance_dirs
+WHERE instance_name = '$(sql_escape "$instance_name")'
+ORDER BY is_primary DESC, rowid ASC;
+EOF
+}
+
+vm_find_blocking_running_vm() {
+    local allowed_vm_name="${1:-}"
+    local running_vms
+    running_vms=$(tart list --format json | jq -r '.[] | select(.State == "running") | .Name')
+
+    if [[ -n "$running_vms" ]]; then
+        local vm_name
+        while IFS= read -r vm_name; do
+            case "$vm_name" in
+                "$allowed_vm_name"|"$BASE_VM_NAME"|"$OCI_VM_NAME"|clodpod-tmp*|clodpod-oci-tmp*)
+                    continue
+                    ;;
+                clodpod-*)
+                    echo "$vm_name"
+                    return 0
+                    ;;
+            esac
+        done <<< "$running_vms"
+    fi
+
+    return 1
+}
+
 get_setting() {
     local key="$1"
     local default_value="${2:-}"
@@ -980,35 +1031,123 @@ EOF
     fi
 }
 
+get_relative_directory_from_root() {
+    local root_path="$1"
+    local current_dir
+    local resolved_root
+
+    current_dir="$(resolve_physical_path "$PWD" 2>/dev/null || return 1)"
+    resolved_root="$(resolve_physical_path "$root_path" 2>/dev/null || return 1)"
+
+    if [[ "$current_dir" == "$resolved_root" ]] || [[ "$current_dir" == "$resolved_root"/* ]]; then
+        local relative_path="${current_dir#"$resolved_root"}"
+        relative_path="${relative_path#/}"
+        echo "$relative_path"
+        return 0
+    fi
+
+    return 1
+}
+
 # Check if current working directory is inside active project and returns RELATIVE_PATH
 # Returns 0 if inside the project, 1 otherwise
 get_relative_project_directory() {
     local project_name
     project_name="$1"
-    local current_dir
-    current_dir="$(resolve_physical_path "$PWD")"
-    
     local path
     path=$(sqlite3 "$DB_FILE" <<EOF || return 1
 SELECT path FROM projects WHERE name = '$(sql_escape "$project_name")' AND active > 0 LIMIT 1;
 EOF
 )
-    
-    if [[ -n "$path" ]]; then
-        # Check if current directory is inside this project
-        path="$(resolve_physical_path "$path" || true)"
-        if [[ "$current_dir" == "$path" ]] || [[ "$current_dir" == "$path"/* ]]; then
-            # Calculate relative path from project root
-            local relative_path="${current_dir#"$path"}"
-            relative_path="${relative_path#/}"  # Remove leading slash if present
 
-            # Output the results separated by pipe
-            echo "${relative_path}"
-            return 0
-        fi
+    [[ -n "$path" ]] || return 1
+    get_relative_directory_from_root "$path"
+}
+
+get_local_network_error() {
+    local vm_name="$1"
+    local term_program="${TERM_PROGRAM:-e.g. ghostty, kitty, iTerm, WezTerm}"
+
+    cat <<EOF
+
+ERROR: unable to connect to $vm_name.
+
+Your terminal app ($term_program)
+has not been granted "Local Network" access rights,
+which are required to SSH to the Virtual Machine.
+
+- Open "System Settings.app"
+- Navigate to "Privacy & Security"
+- Select "Local Network"
+- Grant access to your terminal application
+
+EOF
+}
+
+encode_command_args() {
+    local command_args_b64=""
+    if [[ ${#COMMAND_ARGS[@]} -gt 0 ]]; then
+        command_args_b64="$(printf '%s\0' "${COMMAND_ARGS[@]}" | base64 | tr -d '\n')"
     fi
-    
-    return 1
+    echo "$command_args_b64"
+}
+
+get_vm_ip_or_abort() {
+    local vm_name="$1"
+
+    debug "Checking $vm_name IP connectivity"
+    local ipaddr
+    ipaddr="$(tart ip --wait 20 "$vm_name")"
+    if ! nc -z "$ipaddr" 22 ; then
+        error "$(get_local_network_error "$vm_name")"
+        read -n 1 -s -r -p "Press any key to open System Settings"
+        open "/System/Library/PreferencePanes/Security.prefPane"
+    fi
+
+    echo "$ipaddr"
+}
+
+ssh_into_vm() {
+    local vm_name="$1"
+    local project_name="${2:-}"
+    local initial_dir="${3:-}"
+    local ipaddr
+    local command_args_b64
+
+    ipaddr="$(get_vm_ip_or_abort "$vm_name")"
+    debug "Connect to $vm_name (ssh clodpod@$ipaddr)"
+
+    command_args_b64="$(encode_command_args)"
+
+    exec ssh \
+        -q \
+        -tt \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -i "$SSH_KEYFILE_PRIV" \
+        "clodpod@$ipaddr" \
+        /usr/bin/env \
+            "TERM=xterm-256color" \
+            "PROJECT=$project_name" \
+            "INITIAL_DIR=$initial_dir" \
+            "COMMAND=${COMMAND:-}" \
+            "COMMAND_ARGS_B64=$command_args_b64" \
+            zsh --login || true
+}
+
+vm_sync_authorized_key() {
+    local vm_name="$1"
+    local pub_key_b64
+
+    pub_key_b64="$(base64 < "$SSH_KEYFILE_PUB" | tr -d '\n')"
+    tart exec -it "$vm_name" \
+        "/usr/bin/env" "PUB_KEY_B64=$pub_key_b64" \
+        bash -lc '
+            sudo install -d -m 700 -o clodpod -g clodpod /Users/clodpod/.ssh
+            printf "%s" "$PUB_KEY_B64" | /usr/bin/base64 -D | sudo tee /Users/clodpod/.ssh/authorized_keys >/dev/null
+            sudo chown clodpod:clodpod /Users/clodpod/.ssh/authorized_keys
+            sudo chmod 600 /Users/clodpod/.ssh/authorized_keys
+        '
 }
 
 show_version() {

--- a/clod
+++ b/clod
@@ -157,32 +157,6 @@ array_contains() {
     return 1
 }
 
-vm_name_to_vm_name() {
-    printf 'clodpod-%s\n' "$1"
-}
-
-vm_name_reserved() {
-    case "$1" in
-        xcode|oci-base|xcode-base|tmp*|oci-tmp*)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-vm_validate_name() {
-    local name="$1"
-
-    if [[ ! "$name" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*$ ]]; then
-        abort "Error: invalid instance name ($name)"
-    fi
-    if vm_name_reserved "$name"; then
-        abort "Error: reserved instance name ($name)"
-    fi
-}
-
 ensure_ssh_key() {
     SSH_KEY_CREATED=false
     if [[ ! -f "$SSH_KEYFILE_PRIV" ]] || [[ ! -f "$SSH_KEYFILE_PUB" ]]; then
@@ -263,6 +237,32 @@ refresh_guest_home() {
     mkdir -p "$(dirname "$guest_known_hosts")"
     ssh-keyscan github.com > "$guest_known_hosts"
     chmod 600 "$guest_known_hosts"
+}
+
+vm_name_to_vm_name() {
+    printf 'clodpod-%s\n' "$1"
+}
+
+vm_name_reserved() {
+    case "$1" in
+        xcode|oci-base|xcode-base|tmp*|oci-tmp*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+vm_validate_name() {
+    local name="$1"
+
+    if [[ ! "$name" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*$ ]]; then
+        abort "Error: invalid instance name ($name)"
+    fi
+    if vm_name_reserved "$name"; then
+        abort "Error: reserved instance name ($name)"
+    fi
 }
 
 install_tools () {
@@ -1258,6 +1258,20 @@ vm_shell() {
     ssh_into_vm "$vm_name" "$primary_name" "$initial_dir"
 }
 
+vm_stop_instance() {
+    local instance_name="$1"
+    local vm_name
+
+    vm_name="$(vm_get_instance_vm_name "$instance_name")"
+    [[ -n "$vm_name" ]] || abort "Error: instance not found ($instance_name)"
+
+    if ! get_vm_exists "$vm_name"; then
+        return 0
+    fi
+
+    stop_vm "$vm_name"
+}
+
 vm_delete_instance_records() {
     local instance_name="$1"
 
@@ -1319,20 +1333,6 @@ list_all() {
     fi
 }
 
-vm_stop_instance() {
-    local instance_name="$1"
-    local vm_name
-
-    vm_name="$(vm_get_instance_vm_name "$instance_name")"
-    [[ -n "$vm_name" ]] || abort "Error: instance not found ($instance_name)"
-
-    if ! get_vm_exists "$vm_name"; then
-        return 0
-    fi
-
-    stop_vm "$vm_name"
-}
-
 show_version() {
     echo "clod version $VERSION"
     exit 0
@@ -1377,13 +1377,25 @@ show_help() {
     echo "  co, codex  [PATH] [NAME]  Run OpenAI Codex"
     echo "  cu, cursor [PATH] [NAME]  Run Cursor Agent"
     echo "  g,  gemini [PATH] [NAME]  Run Google Gemini"
-    echo "  s,  shell  [PATH] [NAME]  Run zsh shell"
+    echo "  cr, create NAME [--dir name:path ...]"
+    echo "                           Create a named VM from the base image"
+    echo "  s,  shell  [NAME|PATH] [NAME]"
+    echo "                           Run zsh shell for a named VM or legacy project"
     echo "  a,  add PATH [NAME]       Add a new project"
     echo "  rm, remove <identifier>   Remove project by name or path"
-    echo "  ls, list                  List all projects"
+    echo "  ls, list                  List named instances and projects"
     echo "  st, status                Show sudo, Layer 0/base/dst state, and image provenance"
     echo "      start                 Start virtual machine"
-    echo "      stop                  Stop virtual machine"
+    echo "      stop [NAME]           Stop a named VM or all clodpod VMs"
+    echo "      destroy NAME          Delete a named VM"
+    echo "      destroy --all         Delete all named VMs"
+    echo ""
+    echo "Examples:"
+    echo "  clod create dev --dir project:/Users/me/src/app --dir libs:/Users/me/src/libs"
+    echo "  clod shell dev"
+    echo "  clod shell /Users/me/src/app"
+    echo "  clod stop dev"
+    echo "  clod destroy --all"
     echo ""
     echo "Arguments after -- are passed to the command (claude, codex, cursor, gemini, shell)"
 }

--- a/clod
+++ b/clod
@@ -1150,6 +1150,114 @@ vm_sync_authorized_key() {
         '
 }
 
+vm_list() {
+    local result
+    result=$(sqlite3 -separator '|' "$DB_FILE" <<EOF || return 1
+SELECT name, vm_name FROM instances ORDER BY created_at DESC, name ASC;
+EOF
+)
+
+    [[ -n "$result" ]] || return 1
+
+    echo "INSTANCES"
+    printf "%-20s %-12s %-15s %s\n" "NAME" "STATE" "IP" "DIRS"
+
+    local instance_name
+    local vm_name
+    while IFS='|' read -r instance_name vm_name; do
+        local state
+        local ipaddr="-"
+        local dir_rows
+        local dirs=""
+
+        state="$(get_vm_state "$vm_name")"
+        [[ -n "$state" ]] || state="not created"
+        if [[ "$state" == "running" ]]; then
+            ipaddr="$(tart ip "$vm_name" 2>/dev/null || echo "-")"
+            [[ -n "$ipaddr" ]] || ipaddr="-"
+        fi
+
+        dir_rows="$(vm_get_instance_dirs "$instance_name")"
+        if [[ -n "$dir_rows" ]]; then
+            local dir_name
+            local dir_path
+            local is_primary
+            while IFS='|' read -r dir_name dir_path is_primary; do
+                local entry="${dir_name}:${dir_path}"
+                if [[ "$is_primary" -eq 1 ]]; then
+                    entry="$entry (primary)"
+                fi
+                if [[ -n "$dirs" ]]; then
+                    dirs="$dirs, "
+                fi
+                dirs="${dirs}${entry}"
+            done <<< "$dir_rows"
+        fi
+        [[ -n "$dirs" ]] || dirs="-"
+
+        printf "%-20s %-12s %-15s %s\n" "$instance_name" "$state" "$ipaddr" "$dirs"
+    done <<< "$result"
+}
+
+vm_shell() {
+    local instance_name="$1"
+    local vm_name
+    local blocking_vm
+
+    vm_name="$(vm_get_instance_vm_name "$instance_name")"
+    [[ -n "$vm_name" ]] || abort "Error: instance not found ($instance_name)"
+
+    if ! get_vm_exists "$vm_name"; then
+        abort "Error: VM missing for instance $instance_name ($vm_name). Destroy and recreate it."
+    fi
+
+    blocking_vm="$(vm_find_blocking_running_vm "$vm_name" || true)"
+    if [[ -n "$blocking_vm" ]]; then
+        abort "Error: another clodpod VM is running ($blocking_vm). Stop it first with 'clod stop'."
+    fi
+
+    ensure_ssh_key
+
+    local dir_args=()
+    local primary_name=""
+    local primary_path=""
+    local dir_rows
+    dir_rows="$(vm_get_instance_dirs "$instance_name")"
+    if [[ -n "$dir_rows" ]]; then
+        local dir_name
+        local dir_path
+        local is_primary
+        while IFS='|' read -r dir_name dir_path is_primary; do
+            if [[ ! -d "$dir_path" ]]; then
+                warn "Instance directory missing on host: $dir_name ($dir_path)"
+                continue
+            fi
+
+            dir_args+=("--dir" "${dir_name}:${dir_path}")
+            if [[ "$is_primary" -eq 1 ]] && [[ -z "$primary_name" ]]; then
+                primary_name="$dir_name"
+                primary_path="$dir_path"
+            fi
+        done <<< "$dir_rows"
+    fi
+
+    if [[ "$(get_vm_state "$vm_name")" != "running" ]]; then
+        vm_run "$vm_name" ${dir_args[@]+"${dir_args[@]}"}
+    fi
+
+    if [[ "${SSH_KEY_CREATED:-false}" == "true" ]]; then
+        vm_sync_authorized_key "$vm_name"
+    fi
+
+    local initial_dir=""
+    if [[ -n "$primary_path" ]]; then
+        initial_dir="$(get_relative_directory_from_root "$primary_path" 2>/dev/null || true)"
+        debug "initial directory: ${initial_dir:-}"
+    fi
+
+    ssh_into_vm "$vm_name" "$primary_name" "$initial_dir"
+}
+
 show_version() {
     echo "clod version $VERSION"
     exit 0
@@ -1358,6 +1466,7 @@ case "${1:-}" in
         ;;
     shell|sh|s)
         unset COMMAND
+        IS_SHELL_COMMAND=true
         PROJECT_DIR="${2:-}"
         PROJECT_NAME="${3:-}"
         ;;
@@ -1395,6 +1504,25 @@ case "${1:-}" in
         ;;
 esac
 
+if [[ "${IS_SHELL_COMMAND:-}" == "true" ]]; then
+    if [[ -n "${PROJECT_DIR:-}" ]] && vm_instance_exists "$PROJECT_DIR"; then
+        vm_shell "$PROJECT_DIR"
+        exit 0
+    fi
+
+    if [[ -z "${PROJECT_DIR:-}" ]]; then
+        instance_count="$(vm_get_instance_count 2>/dev/null || echo 0)"
+        if [[ "${instance_count:-0}" -eq 1 ]]; then
+            only_instance_name="$(vm_get_only_instance_name)"
+            vm_shell "$only_instance_name"
+            exit 0
+        elif [[ "${instance_count:-0}" -gt 1 ]]; then
+            vm_list
+            abort "Multiple instances exist. Specify name: clod shell <name>"
+        fi
+    fi
+fi
+
 # Decide whether sudo-setting changes require rebuild
 STORED_ALLOW_SUDO="$(get_setting "allow_sudo" "false")"
 if [[ "${COMMAND:-}" == "status" ]]; then
@@ -1411,19 +1539,30 @@ fi
 
 # Resolve explicit command target argument
 if [[ -n "${PROJECT_DIR:-}" ]]; then
-    resolved_path="$(resolve_physical_path "$PROJECT_DIR" 2>/dev/null || true)"
-    if [[ -d "$resolved_path" ]]; then
-        # PATH [NAME] form
-        add_project "$PROJECT_DIR" "$PROJECT_NAME"
-        SHOULD_SELECT_PROJECT=false
-    elif project_path="$(get_project_path_by_name "$PROJECT_DIR")" && [[ -n "$project_path" ]]; then
+    if [[ "${IS_SHELL_COMMAND:-}" == "true" ]] && project_path="$(get_project_path_by_name "$PROJECT_DIR")" && [[ -n "$project_path" ]]; then
         # NAME-only form
         PROJECT_NAME="$PROJECT_DIR"
         PROJECT_DIR="$project_path"
         SHOULD_SELECT_PROJECT=false
         set_active_project "$PROJECT_NAME" "$PROJECT_DIR"
     else
-        abort "Error: Project not found ($PROJECT_DIR)"
+        resolved_path="$(resolve_physical_path "$PROJECT_DIR" 2>/dev/null || true)"
+        if [[ -d "$resolved_path" ]]; then
+            # PATH [NAME] form
+            add_project "$PROJECT_DIR" "$PROJECT_NAME"
+            SHOULD_SELECT_PROJECT=false
+        elif project_path="$(get_project_path_by_name "$PROJECT_DIR")" && [[ -n "$project_path" ]]; then
+            # NAME-only form
+            PROJECT_NAME="$PROJECT_DIR"
+            PROJECT_DIR="$project_path"
+            SHOULD_SELECT_PROJECT=false
+            set_active_project "$PROJECT_NAME" "$PROJECT_DIR"
+        else
+            if [[ "${IS_SHELL_COMMAND:-}" == "true" ]]; then
+                abort "Error: project path or instance not found ($PROJECT_DIR)"
+            fi
+            abort "Error: Project not found ($PROJECT_DIR)"
+        fi
     fi
 fi
 

--- a/clod
+++ b/clod
@@ -183,6 +183,88 @@ vm_validate_name() {
     fi
 }
 
+ensure_ssh_key() {
+    SSH_KEY_CREATED=false
+    if [[ ! -f "$SSH_KEYFILE_PRIV" ]] || [[ ! -f "$SSH_KEYFILE_PUB" ]]; then
+        mkdir -p "$SSH_DIR"
+        ssh-keygen -t ed25519 \
+            -f "$SSH_KEYFILE_PRIV" \
+            -N "" \
+            -q \
+            -C "clodpod-${USER}@${HOSTNAME}"
+        SSH_KEY_CREATED=true
+        REBUILD_DST=true
+        # Sync new key to all existing named VMs
+        sync_ssh_key_to_all_instances
+    fi
+}
+
+# Push updated authorized_keys to all named instances that exist as tart VMs.
+# Temporarily starts stopped VMs, pushes key, stops them again.
+sync_ssh_key_to_all_instances() {
+    local instance_names
+    instance_names="$(sqlite3 "$DB_FILE" "SELECT vm_name FROM instances;" 2>/dev/null)" || return 0
+    [[ -n "$instance_names" ]] || return 0
+
+    local pub_key
+    pub_key="$(cat "$SSH_KEYFILE_PUB")"
+
+    # Also sync to legacy clodpod-xcode if it exists
+    if get_vm_exists "$DST_VM_NAME" && ! printf '%s\n' "$instance_names" | grep -q "^${DST_VM_NAME}$"; then
+        instance_names="${instance_names:+$instance_names
+}$DST_VM_NAME"
+    fi
+
+    while IFS= read -r vm; do
+        if ! get_vm_exists "$vm"; then
+            continue
+        fi
+        local was_stopped=false
+        if [[ "$(get_vm_state "$vm")" != "running" ]]; then
+            was_stopped=true
+            tart run --no-graphics "$vm" </dev/null &>/dev/null & disown
+            # Wait with timeout, skip this VM if it won't start
+            local elapsed=0
+            while [[ "$(get_vm_state "$vm")" != "running" ]] && [[ "$elapsed" -lt 30 ]]; do
+                sleep 1
+                elapsed=$((elapsed + 1))
+            done
+            if [[ "$(get_vm_state "$vm")" != "running" ]]; then
+                warn "Could not start $vm for SSH key sync — skipping"
+                continue
+            fi
+        fi
+        debug "Syncing SSH key to $vm..."
+        printf '%s\n' "$pub_key" | tart exec "$vm" -- \
+            bash -c 'cat > /Users/clodpod/.ssh/authorized_keys && chmod 600 /Users/clodpod/.ssh/authorized_keys' \
+            2>/dev/null || true
+        if [[ "$was_stopped" == "true" ]]; then
+            tart stop "$vm" 2>/dev/null || true
+        fi
+    done <<< "$instance_names"
+}
+
+refresh_guest_home() {
+    debug "Configuring credentials..."
+
+    local git_user_name
+    local git_user_email
+    git_user_name="$(git config --global --get user.name 2>/dev/null || echo "")"
+    git_user_email="$(git config --global --get user.email 2>/dev/null || echo "")"
+    git config set -f "$WORKSPACE/guest/home/.gitconfig" user.name "$git_user_name"
+    git config set -f "$WORKSPACE/guest/home/.gitconfig" user.email "$git_user_email"
+
+    local guest_authorized_keys="$WORKSPACE/guest/home/.ssh/authorized_keys"
+    mkdir -p "$(dirname "$guest_authorized_keys")"
+    cp "$SSH_KEYFILE_PUB" "$guest_authorized_keys"
+    chmod 600 "$guest_authorized_keys"
+
+    local guest_known_hosts="$WORKSPACE/guest/home/.ssh/known_hosts"
+    mkdir -p "$(dirname "$guest_known_hosts")"
+    ssh-keyscan github.com > "$guest_known_hosts"
+    chmod 600 "$guest_known_hosts"
+}
+
 install_tools () {
     # Install brew
     if ! command -v brew &> /dev/null ; then
@@ -1082,18 +1164,7 @@ check_oci_provenance
 ###############################################################################
 # Create passwordless SSH key with permission to remotely login to guest
 ###############################################################################
-SSH_DIR="$HOME/.ssh"
-SSH_KEYFILE_PRIV="$SSH_DIR/id_ed25519_clodpod"
-SSH_KEYFILE_PUB="$SSH_KEYFILE_PRIV.pub"
-if [[ ! -f "$SSH_KEYFILE_PRIV" ]] || [[ ! -f "$SSH_KEYFILE_PUB" ]]; then
-    mkdir -p "$SSH_DIR"
-    ssh-keygen -t ed25519 \
-        -f "$SSH_KEYFILE_PRIV" \
-        -N "" \
-        -q \
-        -C "clodpod-${USER}@${HOSTNAME}"
-    REBUILD_DST=true
-fi
+ensure_ssh_key
 
 if [[ "${REBUILD_OCI:-}" != "" ]]; then
     REBUILD_BASE=true
@@ -1144,25 +1215,7 @@ fi
 # Configure virtual machine settings
 ###############################################################################
 if [[ "${REBUILD_DST:-}" != "" ]]; then
-    debug "Configuring credentials..."
-
-    # Get git config from host
-    GIT_USER_NAME=$(git config --global --get user.name 2>/dev/null || echo "")
-    GIT_USER_EMAIL=$(git config --global --get user.email 2>/dev/null || echo "")
-    git config set -f "$WORKSPACE/guest/home/.gitconfig" user.name "$GIT_USER_NAME"
-    git config set -f "$WORKSPACE/guest/home/.gitconfig" user.email "$GIT_USER_EMAIL"
-
-    # Add SSH public key to host's authorized_keys
-    GUEST_AUTHORIZED_KEYS="$WORKSPACE/guest/home/.ssh/authorized_keys"
-    mkdir -p "$(dirname "$GUEST_AUTHORIZED_KEYS")"
-    cp "$SSH_KEYFILE_PUB" "$GUEST_AUTHORIZED_KEYS"
-    chmod 600 "$GUEST_AUTHORIZED_KEYS"
-
-    # Add GitHub to known hosts
-    GUEST_KNOWN_HOSTS="$WORKSPACE/guest/home/.ssh/known_hosts"
-    mkdir -p "$(dirname "$GUEST_KNOWN_HOSTS")"
-    ssh-keyscan github.com > "$GUEST_KNOWN_HOSTS"
-    chmod 600 "$GUEST_KNOWN_HOSTS"
+    refresh_guest_home
 fi
 
 # https://github.com/webcoyote/clodpod/issues/5

--- a/clod
+++ b/clod
@@ -1258,6 +1258,57 @@ vm_shell() {
     ssh_into_vm "$vm_name" "$primary_name" "$initial_dir"
 }
 
+vm_delete_instance_records() {
+    local instance_name="$1"
+
+    sqlite3 "$DB_FILE" <<EOF
+BEGIN IMMEDIATE;
+DELETE FROM instance_dirs WHERE instance_name = '$(sql_escape "$instance_name")';
+DELETE FROM instances WHERE name = '$(sql_escape "$instance_name")';
+COMMIT;
+EOF
+}
+
+vm_destroy_instance() {
+    local instance_name="$1"
+    local vm_name
+
+    vm_name="$(vm_get_instance_vm_name "$instance_name")"
+    [[ -n "$vm_name" ]] || abort "Error: instance not found ($instance_name)"
+
+    if get_vm_exists "$vm_name"; then
+        stop_vm "$vm_name"
+        tart delete "$vm_name" 2>/dev/null || true
+        if get_vm_exists "$vm_name"; then
+            abort "Failed to delete VM $vm_name — DB records kept so destroy can be retried"
+        fi
+    fi
+
+    vm_delete_instance_records "$instance_name"
+}
+
+vm_destroy() {
+    [[ $# -gt 0 ]] || abort "Usage: clod destroy <name> | --all"
+
+    if [[ "${1:-}" == "--all" ]]; then
+        [[ $# -eq 1 ]] || abort "Error: destroy --all does not accept additional arguments"
+
+        local instance_names
+        instance_names="$(vm_get_instance_names)"
+        if [[ -n "$instance_names" ]]; then
+            local instance_name
+            while IFS= read -r instance_name; do
+                [[ -n "$instance_name" ]] || continue
+                vm_destroy_instance "$instance_name"
+            done <<< "$instance_names"
+        fi
+        return 0
+    fi
+
+    [[ $# -eq 1 ]] || abort "Error: destroy accepts exactly one instance name"
+    vm_destroy_instance "$1"
+}
+
 list_all() {
     if vm_list; then
         echo ""
@@ -1378,6 +1429,14 @@ for arg in "$@"; do
             done
             shift
             vm_create "$@"
+            exit 0
+            ;;
+        destroy)
+            while [[ "${1:-}" != "$arg" ]]; do
+                shift
+            done
+            shift
+            vm_destroy "$@"
             exit 0
             ;;
         *)

--- a/clod
+++ b/clod
@@ -1258,6 +1258,16 @@ vm_shell() {
     ssh_into_vm "$vm_name" "$primary_name" "$initial_dir"
 }
 
+list_all() {
+    if vm_list; then
+        echo ""
+        echo "PROJECTS"
+        list_projects
+    else
+        list_projects
+    fi
+}
+
 vm_stop_instance() {
     local instance_name="$1"
     local vm_name
@@ -1504,7 +1514,7 @@ case "${1:-}" in
         exit 0
         ;;
     list|ls|l)
-        list_projects
+        list_all
         exit 0
         ;;
     status|st)

--- a/clod
+++ b/clod
@@ -624,6 +624,124 @@ SELECT path FROM projects WHERE name = '$(sql_escape "$name")' LIMIT 1;
 EOF
 }
 
+vm_create() {
+    local instance_name="${1:-}"
+    shift || true
+
+    [[ -n "$instance_name" ]] || abort "Usage: clod create <name> [--dir name:path]..."
+    vm_validate_name "$instance_name"
+
+    if vm_instance_exists "$instance_name"; then
+        abort "Error: instance already exists ($instance_name)"
+    fi
+
+    local final_vm_name
+    final_vm_name="$(vm_name_to_vm_name "$instance_name")"
+    if get_vm_exists "$final_vm_name"; then
+        abort "Error: tart VM already exists outside the database ($final_vm_name)"
+    fi
+
+    local dir_names=()
+    local dir_paths=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dir)
+                [[ $# -ge 2 ]] || abort "Error: --dir requires name:path"
+
+                local dir_spec="$2"
+                shift 2
+
+                [[ "$dir_spec" == *:* ]] || abort "Error: invalid --dir value ($dir_spec)"
+                local dir_name="${dir_spec%%:*}"
+                local dir_path_spec="${dir_spec#*:}"
+                [[ -n "$dir_name" ]] || abort "Error: missing directory name in --dir"
+                [[ -n "$dir_path_spec" ]] || abort "Error: missing directory path in --dir"
+                [[ "$dir_name" != "__install" ]] || abort "Error: reserved directory name (__install)"
+                if array_contains "$dir_name" ${dir_names[@]+"${dir_names[@]}"}; then
+                    abort "Error: duplicate --dir name ($dir_name)"
+                fi
+
+                local dir_path
+                dir_path="$(resolve_physical_path "$dir_path_spec" 2>/dev/null || true)"
+                if [[ ! -d "$dir_path" ]]; then
+                    abort "Error: directory not found ($dir_path_spec)"
+                fi
+
+                dir_names+=("$dir_name")
+                dir_paths+=("$dir_path")
+                ;;
+            *)
+                abort "Error: unknown create option ($1)"
+                ;;
+        esac
+    done
+
+    if ! get_vm_exists "$BASE_VM_NAME"; then
+        abort "Error: base VM missing. Run 'clod shell' first to bootstrap it."
+    fi
+
+    ensure_ssh_key
+    refresh_guest_home
+
+    TMP_VM_NAME="clodpod-tmp-$(openssl rand -hex 8)"
+    trap cleanup_tmp_vm EXIT
+
+    clone_vm "$BASE_VM_NAME" "$TMP_VM_NAME"
+
+    local vm_args=()
+    local i=0
+    while [[ "$i" -lt "${#dir_names[@]}" ]]; do
+        vm_args+=("--dir" "${dir_names[$i]}:${dir_paths[$i]}")
+        i=$((i + 1))
+    done
+    vm_args+=("--dir" "__install:$WORKSPACE/guest")
+    vm_run "$TMP_VM_NAME" "${vm_args[@]}"
+
+    trace "Running configure.sh..."
+    if ! tart exec -it "$TMP_VM_NAME" \
+        "/usr/bin/env" "VERBOSE=$VERBOSE" bash \
+        "/Volumes/My Shared Files/__install/configure.sh"; then
+        abort "configure.sh failed — named VM will not be saved"
+    fi
+
+    trace "Stopping $TMP_VM_NAME to flush directory service writes..."
+    stop_vm "$TMP_VM_NAME"
+
+    trace "Renaming $TMP_VM_NAME to $final_vm_name"
+    tart rename "$TMP_VM_NAME" "$final_vm_name"
+    TMP_VM_NAME=""
+
+    local sql
+    sql="BEGIN IMMEDIATE;
+INSERT INTO instances (name, vm_name, created_at)
+VALUES ('$(sql_escape "$instance_name")', '$(sql_escape "$final_vm_name")', datetime('now'));"
+
+    i=0
+    while [[ "$i" -lt "${#dir_names[@]}" ]]; do
+        local is_primary=0
+        if [[ "$i" -eq 0 ]]; then
+            is_primary=1
+        fi
+        sql="${sql}
+INSERT INTO instance_dirs (instance_name, dir_name, dir_path, is_primary)
+VALUES ('$(sql_escape "$instance_name")', '$(sql_escape "${dir_names[$i]}")', '$(sql_escape "${dir_paths[$i]}")', $is_primary);"
+        i=$((i + 1))
+    done
+    sql="${sql}
+COMMIT;"
+
+    if ! printf '%s\n' "$sql" | sqlite3 "$DB_FILE"; then
+        warn "DB insert failed — removing VM $final_vm_name"
+        tart delete "$final_vm_name" 2>/dev/null || true
+        if get_vm_exists "$final_vm_name"; then
+            abort "Failed to record instance AND failed to delete VM $final_vm_name — orphan VM left behind"
+        fi
+        abort "Failed to record instance $instance_name"
+    fi
+
+    info "Created instance $instance_name"
+}
+
 read_menu_key() {
     local input_fd="$1"
     local esc_seq="$2"
@@ -972,6 +1090,30 @@ show_status() {
     echo "stored image: $stored_image"
     echo "current image: $MACOS_IMAGE"
 }
+
+# Intercept commands that need their own option parsing before the global loop.
+# But let -h/--help/--version pass through to the normal handler.
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help|--version|-V)
+            break  # let global parser handle these
+            ;;
+        -*)
+            continue
+            ;;
+        create|cr)
+            while [[ "${1:-}" != "$arg" ]]; do
+                shift
+            done
+            shift
+            vm_create "$@"
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 # Parse optional arguments
 NEW_ARGS=()

--- a/clod
+++ b/clod
@@ -83,6 +83,10 @@ OCI_VM_NAME="clodpod-oci-base"
 BASE_VM_NAME="clodpod-xcode-base"
 DST_VM_NAME="clodpod-xcode"
 DB_FILE="$WORKSPACE/.clodpod.sqlite"
+SSH_DIR="$HOME/.ssh"
+SSH_KEYFILE_PRIV="$SSH_DIR/id_ed25519_clodpod"
+SSH_KEYFILE_PUB="$SSH_KEYFILE_PRIV.pub"
+SSH_KEY_CREATED=false
 
 MACOS_IMAGE="ghcr.io/cirruslabs/macos-$MACOS_VERSION-$MACOS_FLAVOR:latest"
 debug "MacOS image: $MACOS_IMAGE"
@@ -139,6 +143,43 @@ resolve_physical_path() {
     else
         dir="$(builtin cd -P "$(dirname "$path")" 2>/dev/null && pwd -P)" || return 1
         echo "$dir/$(basename "$path")"
+    fi
+}
+
+array_contains() {
+    local needle="$1"
+    shift || true
+
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+vm_name_to_vm_name() {
+    printf 'clodpod-%s\n' "$1"
+}
+
+vm_name_reserved() {
+    case "$1" in
+        xcode|oci-base|xcode-base|tmp*|oci-tmp*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+vm_validate_name() {
+    local name="$1"
+
+    if [[ ! "$name" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*$ ]]; then
+        abort "Error: invalid instance name ($name)"
+    fi
+    if vm_name_reserved "$name"; then
+        abort "Error: reserved instance name ($name)"
     fi
 }
 
@@ -307,6 +348,35 @@ CREATE TABLE IF NOT EXISTS settings (
     value TEXT NOT NULL,
     updated_at TEXT DEFAULT (datetime('now'))
 );
+CREATE TABLE IF NOT EXISTS instances (
+    name TEXT PRIMARY KEY,
+    vm_name TEXT UNIQUE NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS instance_dirs (
+    instance_name TEXT NOT NULL,
+    dir_name TEXT NOT NULL,
+    dir_path TEXT NOT NULL,
+    is_primary INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (instance_name, dir_name)
+);
+EOF
+}
+
+vm_instance_exists() {
+    local instance_name="$1"
+    local count
+    count=$(sqlite3 "$DB_FILE" <<EOF 2>/dev/null || echo 0
+SELECT COUNT(*) FROM instances WHERE name = '$(sql_escape "$instance_name")';
+EOF
+)
+    [[ "${count:-0}" -gt 0 ]]
+}
+
+vm_get_instance_vm_name() {
+    local instance_name="$1"
+    sqlite3 "$DB_FILE" <<EOF
+SELECT vm_name FROM instances WHERE name = '$(sql_escape "$instance_name")' LIMIT 1;
 EOF
 }
 


### PR DESCRIPTION
This PR adds named images/VMs that let you keep separate environments
for different projects or worktree branches and switch between them.
Each is a cheap APFS CoW clone of the base — creation takes seconds.

    clod create project --dir project:/path/to/project
    clod create featureX --dir work:/path/to/worktree
    clod shell project
    clod stop project
    clod shell featureX
    clod destroy project
    clod list

This allows running one VM at a time. Trying to start another while
one is running gives a clear error with a hint to stop it first.

The existing clod shell / clod stop / clod list work as before if
there is only one VM defined. When there are multiple VMs it requires
the name of the VM.

The next step after this is to make parallel running VMs possible.