### PR TITLE
Add --vm-count to split memory budget across VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,13 @@ per-instance RAM and the total budget:
     # Override RAM for one session
     clod shell --ram 6G dev
 
+    # Split budget across multiple VMs (default: 1)
+    clod set --vm-count 2
+
     # Reset to dynamic (use remaining budget)
     clod set --ram default dev
     clod set --max-memory default
+    clod set --vm-count default
 
 
 ## macOS versions

--- a/clod
+++ b/clod
@@ -365,7 +365,10 @@ resolve_and_check_memory_budget() {
     remaining_mb=$((budget_mb - used_mb))
 
     if [[ "$requested_mb" -eq 0 ]]; then
-        resolved_mb="$remaining_mb"
+        local vm_count
+        vm_count="$(get_setting "vm_count" "1")"
+        [[ "$vm_count" =~ ^[0-9]+$ ]] && [[ "$vm_count" -ge 1 ]] || vm_count=1
+        resolved_mb=$((budget_mb / vm_count))
     else
         resolved_mb="$requested_mb"
     fi
@@ -1528,6 +1531,7 @@ vm_set() {
     local ram_value=""
     local ram_name=""
     local max_memory_value=""
+    local vm_count_value=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -1545,6 +1549,11 @@ vm_set() {
             --max-memory)
                 [[ $# -ge 2 ]] || abort "Usage: clod set --max-memory <size|default>"
                 max_memory_value="$2"
+                shift 2
+                ;;
+            --vm-count)
+                [[ $# -ge 2 ]] || abort "Usage: clod set --vm-count <N|default>"
+                vm_count_value="$2"
                 shift 2
                 ;;
             *)
@@ -1604,8 +1613,26 @@ vm_set() {
         fi
     fi
 
-    if [[ -z "$ram_value" ]] && [[ -z "$max_memory_value" ]]; then
-        abort "Usage: clod set [--ram <size|default> <name>] [--max-memory <size|default>]"
+    if [[ -n "$vm_count_value" ]]; then
+        if [[ "$vm_count_value" == "default" ]]; then
+            sqlite3 "$DB_FILE" "DELETE FROM settings WHERE key = 'vm_count';"
+            info "Reset VM count to default (1)"
+        else
+            if [[ ! "$vm_count_value" =~ ^[0-9]+$ ]] || [[ "$vm_count_value" -lt 1 ]]; then
+                abort "VM count must be a positive integer (got '$vm_count_value')"
+            fi
+            set_setting "vm_count" "$vm_count_value"
+            local per_vm_mb
+            per_vm_mb="$(( $(get_memory_budget_mb) / vm_count_value ))"
+            info "Set VM count to ${vm_count_value} (${per_vm_mb} MB per VM)"
+            if [[ "$per_vm_mb" -lt 2048 ]]; then
+                warn "Per-VM share (${per_vm_mb} MB) is below minimum 2048 MB. Dynamic launches will fail."
+            fi
+        fi
+    fi
+
+    if [[ -z "$ram_value" ]] && [[ -z "$max_memory_value" ]] && [[ -z "$vm_count_value" ]]; then
+        abort "Usage: clod set [--ram <size|default> <name>] [--max-memory <size|default>] [--vm-count <N|default>]"
     fi
 }
 
@@ -1614,7 +1641,11 @@ list_all() {
     budget_mb="$(get_memory_budget_mb)"
     local host_ram_mb
     host_ram_mb="$(( $(sysctl -n hw.memsize) / 1048576 ))"
-    echo "Memory budget: ${budget_mb} MB (of ${host_ram_mb} MB)"
+    local vm_count
+    vm_count="$(get_setting "vm_count" "1")"
+    [[ "$vm_count" =~ ^[0-9]+$ ]] && [[ "$vm_count" -ge 1 ]] || vm_count=1
+    local per_vm_mb=$((budget_mb / vm_count))
+    echo "Memory budget: ${budget_mb} MB (of ${host_ram_mb} MB), ${vm_count} VM(s) x ${per_vm_mb} MB"
     echo ""
 
     if vm_list; then
@@ -1685,6 +1716,7 @@ show_help() {
     echo "      destroy --all         Delete all named VMs"
     echo "      set --ram SIZE NAME   Set per-instance RAM (use 'default' to reset)"
     echo "      set --max-memory SIZE Set workspace memory budget (use 'default' to reset)"
+    echo "      set --vm-count N      Split budget across N VMs (use 'default' to reset to 1)"
     echo ""
     echo "Examples:"
     echo "  clod create dev --ram 8G --dir project:/Users/me/src/app"
@@ -1692,6 +1724,7 @@ show_help() {
     echo "  clod shell --ram 6G dev"
     echo "  clod set --ram 10G dev"
     echo "  clod set --max-memory 16G"
+    echo "  clod set --vm-count 2"
     echo "  clod shell /Users/me/src/app"
     echo "  clod stop dev"
     echo "  clod destroy --all"


### PR DESCRIPTION
## Summary

Adds `--vm-count` setting that splits the memory budget evenly across N VMs when no explicit `--ram` is given. Default is 1 (current behavior unchanged).

```
clod set --vm-count 2              # budget split in half
clod create dev --dir project:/p   # gets budget/2
clod create staging --dir work:/w  # gets budget/2
clod create test --ram 4G --dir x:/t  # explicit --ram overrides split
```

```
$ clod list
Memory budget: 20480 MB (of 32768 MB), 2 VM(s) x 10240 MB
```

## How it works

- `resolve_and_check_memory_budget`: when `requested_mb=0`, computes `budget / vm_count` instead of using full remaining budget
- `clod set --vm-count N`: stores in settings DB, validates positive integer, warns if per-VM share < 2048 MB, maybe could be 4096, and that is quite minimal too..
- `clod set --vm-count default`: resets to 1
- `clod list`: shows vm_count and per-VM share in budget header
- Per-instance `--ram` always overrides the split

## Testing done

- `clod set --vm-count 2` → "10240 MB per VM" on 32 GB host
- `clod set --vm-count 20` → warns "below minimum 2048 MB"
- `clod set --vm-count 0` → rejected
- `clod set --vm-count default` → resets to 1
- `clod list` shows correct split
- `bash -n`, shellcheck clean