### PR TITLE
Move user state to ~/.local/share/clodpod/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,5 @@
 .DerivedData/
 xcschememanagement.plist
 **/xcuserdata/
-/.clodpod.sqlite
-
-# Dynamically created files that shouldn't be committed
-guest/home/.gitconfig
-guest/home/.ssh/authorized_keys
-guest/home/.ssh/known_hosts
-
 # User directory for storing files that are not committed
 guest/home/user/

--- a/clod
+++ b/clod
@@ -2,8 +2,20 @@
 # Build a MacOS virtual machine that runs AI agents and developer tools
 set -Eeuo pipefail
 trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
-SCRIPT_DIR="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE="$(builtin cd -P "$SCRIPT_DIR" && pwd)"
+
+# Resolve symlinks (macOS bash 3.2 compatible, no readlink -f)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" = /* ]] || SOURCE="$SOURCE_DIR/$SOURCE"
+done
+WORKSPACE="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
+
+# Homebrew Cellar: use stable opt/ symlink instead of versioned path
+if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+$ ]]; then
+    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}"
+fi
 
 
 ###############################################################################

--- a/clod
+++ b/clod
@@ -245,22 +245,26 @@ sync_ssh_key_to_all_instances() {
 }
 
 refresh_guest_home() {
-    debug "Configuring credentials..."
+    debug "Syncing guest directory..."
+    local guest_dir="$DATA_DIR/guest"
+    mkdir -p "$guest_dir"
+    rsync -a --delete --exclude '.gitconfig' --exclude '.ssh/' "$WORKSPACE/guest/" "$guest_dir/"
 
+    debug "Configuring credentials..."
     local git_user_name
     local git_user_email
     git_user_name="$(git config --global --get user.name 2>/dev/null || echo "")"
     git_user_email="$(git config --global --get user.email 2>/dev/null || echo "")"
-    git config set -f "$WORKSPACE/guest/home/.gitconfig" user.name "$git_user_name"
-    git config set -f "$WORKSPACE/guest/home/.gitconfig" user.email "$git_user_email"
+    git config set -f "$guest_dir/home/.gitconfig" user.name "$git_user_name"
+    git config set -f "$guest_dir/home/.gitconfig" user.email "$git_user_email"
 
-    local guest_authorized_keys="$WORKSPACE/guest/home/.ssh/authorized_keys"
+    local guest_authorized_keys="$guest_dir/home/.ssh/authorized_keys"
     # shellcheck disable=SC2174 # When used with -p, -m only applies to the deepest directory. # Yup, that's fine
     mkdir -m 700 -p "$(dirname "$guest_authorized_keys")"
     cp "$SSH_KEYFILE_PUB" "$guest_authorized_keys"
     chmod 600 "$guest_authorized_keys"
 
-    local guest_known_hosts="$WORKSPACE/guest/home/.ssh/known_hosts"
+    local guest_known_hosts="$guest_dir/home/.ssh/known_hosts"
     # shellcheck disable=SC2174 # When used with -p, -m only applies to the deepest directory. # Yup, that's fine
     mkdir -m 700 -p "$(dirname "$guest_known_hosts")"
     ssh-keyscan github.com > "$guest_known_hosts"
@@ -967,7 +971,7 @@ vm_create() {
         vm_args+=("--dir" "${dir_names[$i]}:${dir_paths[$i]}")
         i=$((i + 1))
     done
-    vm_args+=("--dir" "__install:$WORKSPACE/guest")
+    vm_args+=("--dir" "__install:$DATA_DIR/guest")
     vm_run "$TMP_VM_NAME" 0 "" "${vm_args[@]}"
 
     trace "Running configure.sh..."
@@ -1245,7 +1249,7 @@ EOF
 
     # Always map the guest directory into the VM as "__install"
     # so install/configure scripts are available during build
-    printf '%s\0' "--dir" "__install:$WORKSPACE/guest"
+    printf '%s\0' "--dir" "__install:$DATA_DIR/guest"
 
     if [[ -n "$result" ]]; then
         while IFS='|' read -r name path; do

--- a/clod
+++ b/clod
@@ -97,21 +97,6 @@ DST_VM_NAME="clodpod-xcode"
 DATA_DIR="$HOME/.local/share/clodpod"
 OLD_DB_FILE="$WORKSPACE/.clodpod.sqlite"
 
-# Resolve database location: new XDG path, legacy install path, or fresh install
-resolve_db_file() {
-    if [[ -f "$DATA_DIR/clodpod.sqlite" ]]; then
-        printf '%s' "$DATA_DIR/clodpod.sqlite"
-    elif [[ -f "$OLD_DB_FILE" ]]; then
-        info "Database found at $OLD_DB_FILE"
-        info "Run 'clod migrate' to move it to $DATA_DIR/"
-        info "If you have multiple clodpod checkouts, migrate from only one."
-        printf '%s' "$OLD_DB_FILE"
-    else
-        mkdir -p "$DATA_DIR"
-        printf '%s' "$DATA_DIR/clodpod.sqlite"
-    fi
-}
-DB_FILE="$(resolve_db_file)"
 SSH_DIR="$HOME/.ssh"
 SSH_KEYFILE_PRIV="$SSH_DIR/id_ed25519_clodpod"
 SSH_KEYFILE_PUB="$SSH_KEYFILE_PRIV.pub"
@@ -248,7 +233,7 @@ refresh_guest_home() {
     debug "Syncing guest directory..."
     local guest_dir="$DATA_DIR/guest"
     mkdir -p "$guest_dir"
-    rsync -a --delete --exclude '.gitconfig' --exclude '.ssh/' "$WORKSPACE/guest/" "$guest_dir/"
+    /usr/bin/rsync -a --delete --exclude '.gitconfig' --exclude '.ssh/' "$WORKSPACE/guest/" "$guest_dir/"
 
     debug "Configuring credentials..."
     local git_user_name
@@ -660,6 +645,24 @@ migrate_db() {
     mv "$OLD_DB_FILE" "$DATA_DIR/clodpod.sqlite"
     DB_FILE="$DATA_DIR/clodpod.sqlite"
     info "Migrated database to $DATA_DIR/clodpod.sqlite"
+
+    refresh_guest_home
+}
+
+# Resolve database location: new XDG path, legacy install path, or fresh install
+resolve_db_file() {
+    if [[ -f "$DATA_DIR/clodpod.sqlite" ]]; then
+        printf '%s' "$DATA_DIR/clodpod.sqlite"
+    elif [[ -f "$OLD_DB_FILE" ]]; then
+        info "Database found at $OLD_DB_FILE"
+        info "Run 'clod migrate' to move it to $DATA_DIR/"
+        info "If you have multiple clodpod checkouts, migrate from only one."
+        refresh_guest_home
+        printf '%s' "$OLD_DB_FILE"
+    else
+        mkdir -p "$DATA_DIR"
+        printf '%s' "$DATA_DIR/clodpod.sqlite"
+    fi
 }
 
 init_db() {
@@ -1713,6 +1716,7 @@ show_version() {
 # Setup
 ###############################################################################
 install_tools
+DB_FILE="$(resolve_db_file)"
 init_db
 
 

--- a/clod
+++ b/clod
@@ -94,7 +94,24 @@ VERSION="1.0.20"
 OCI_VM_NAME="clodpod-oci-base"
 BASE_VM_NAME="clodpod-xcode-base"
 DST_VM_NAME="clodpod-xcode"
-DB_FILE="$WORKSPACE/.clodpod.sqlite"
+DATA_DIR="$HOME/.local/share/clodpod"
+OLD_DB_FILE="$WORKSPACE/.clodpod.sqlite"
+
+# Resolve database location: new XDG path, legacy install path, or fresh install
+resolve_db_file() {
+    if [[ -f "$DATA_DIR/clodpod.sqlite" ]]; then
+        printf '%s' "$DATA_DIR/clodpod.sqlite"
+    elif [[ -f "$OLD_DB_FILE" ]]; then
+        info "Database found at $OLD_DB_FILE"
+        info "Run 'clod migrate' to move it to $DATA_DIR/"
+        info "If you have multiple clodpod checkouts, migrate from only one."
+        printf '%s' "$OLD_DB_FILE"
+    else
+        mkdir -p "$DATA_DIR"
+        printf '%s' "$DATA_DIR/clodpod.sqlite"
+    fi
+}
+DB_FILE="$(resolve_db_file)"
 SSH_DIR="$HOME/.ssh"
 SSH_KEYFILE_PRIV="$SSH_DIR/id_ed25519_clodpod"
 SSH_KEYFILE_PUB="$SSH_KEYFILE_PRIV.pub"

--- a/clod
+++ b/clod
@@ -645,6 +645,19 @@ cleanup_tmp_vm () {
 # Escape single quotes for safe SQLite string literals: ' → ''
 sql_escape() { printf '%s' "${1//\'/\'\'}"; }
 
+migrate_db() {
+    if [[ -f "$DATA_DIR/clodpod.sqlite" ]]; then
+        abort "Already migrated: $DATA_DIR/clodpod.sqlite exists"
+    fi
+    if [[ ! -f "$OLD_DB_FILE" ]]; then
+        abort "Nothing to migrate: no database at $OLD_DB_FILE"
+    fi
+    mkdir -p "$DATA_DIR"
+    mv "$OLD_DB_FILE" "$DATA_DIR/clodpod.sqlite"
+    DB_FILE="$DATA_DIR/clodpod.sqlite"
+    info "Migrated database to $DATA_DIR/clodpod.sqlite"
+}
+
 init_db() {
     debug "Creating $DB_FILE database..."
     sqlite3 "$DB_FILE" <<EOF
@@ -1746,6 +1759,7 @@ show_help() {
     echo "      set --ram SIZE NAME   Set per-instance RAM (use 'default' to reset)"
     echo "      set --max-memory SIZE Set workspace memory budget (use 'default' to reset)"
     echo "      set --vm-count N      Split budget across N VMs (use 'default' to reset to 1)"
+    echo "      migrate               Move database to ~/.local/share/clodpod/"
     echo ""
     echo "Examples:"
     echo "  clod create dev --ram 8G --dir project:/Users/me/src/app"
@@ -2011,6 +2025,10 @@ case "${1:-}" in
         ;;
     list|ls|l)
         list_all
+        exit 0
+        ;;
+    migrate)
+        migrate_db
         exit 0
         ;;
     status|st)


### PR DESCRIPTION
## Summary

Move clodpod's per-user state (database, generated guest credentials) out of the
install directory into `~/.local/share/clodpod/`. This separates read-only
installation files from per-user data, following the same XDG conventions that
sandvault uses.

The script now resolves symlinks when determining its install directory and
detects Homebrew Cellar paths, redirecting to the stable `/opt/homebrew/opt/`
symlink. Together these changes make clodpod symlink-safe and Homebrew-installable.

Users with an existing database in the install directory will see a one-time
notice suggesting `clod migrate` to move it to the new location.

Resolves #27

## Changes

- Resolve symlinks in BASH_SOURCE (macOS bash 3.2 compatible, same pattern as sandvault)
- Redirect Homebrew Cellar paths to stable opt/ symlink
- Store database at `~/.local/share/clodpod/clodpod.sqlite`
- Sync guest/ templates from install dir to data dir on each run
- Generate credentials (.gitconfig, .ssh/*) into data dir instead of install dir
- Add `clod migrate` command for explicit database migration
- Clean up .gitignore entries that no longer apply

## Tested

- Fresh install: no existing DB anywhere, `clod list` creates DB at new location
- Legacy DB: removed new DB, `clod list` uses old DB and prints migration notice
- `clod migrate`: moves DB, notice disappears on next run
- `clod migrate` after already migrated: aborts with clear message
- `clod migrate` with nothing to migrate: aborts with clear message
- Symlink from `~/.local/bin/clod`: resolves correctly, finds DB