### PR TITLE
Fix silent ssh exit 255 on clod claude/shell

### DIFF
--- a/clod
+++ b/clod
@@ -1373,6 +1373,7 @@ ssh_into_vm() {
         -tt \
         -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null \
+        -o IdentitiesOnly=yes \
         -i "$SSH_KEYFILE_PRIV" \
         "clodpod@$ipaddr" \
         /usr/bin/env \
@@ -2378,6 +2379,7 @@ exec ssh \
     -tt \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
+    -o IdentitiesOnly=yes \
     -i "$SSH_KEYFILE_PRIV" \
     "clodpod@$IPADDR" \
     /usr/bin/env \

--- a/guest/install.sh
+++ b/guest/install.sh
@@ -153,17 +153,6 @@ sudo dscl . -create /Users/clodpod RealName "clodpod User"
 sudo dscl . -create /Users/clodpod NFSHomeDirectory "$CLODPOD_HOME"
 sudo dscl . -create /Users/clodpod UserShell "/bin/zsh"
 
-# Force opendirectoryd to flush records to disk.
-# In Tart VMs, opendirectoryd holds records in memory and only writes stubs
-# on shutdown. Killing the daemon forces a clean flush before launchd
-# restarts it.
-debug "Flushing opendirectoryd to persist user and group records..."
-sudo killall opendirectoryd
-until dscl . -list /Users &>/dev/null; do
-    sleep 0.5
-done
-sync
-
 # Configure sudo
 if [[ "$ALLOW_SUDO" == "true" ]]; then
     debug "Enabling sudo access for clodpod user..."
@@ -188,6 +177,19 @@ sudo dscl . -passwd /Users/clodpod "$CLODPOD_PASSWORD"
 # Now add to the SSH access group (required for SSH login)
 # do not use sudo dscl; it creates duplicate entries when run more than once
 sudo dseditgroup -o edit -a clodpod -t user com.apple.access_ssh
+
+# Force opendirectoryd to flush records to disk.
+# In Tart VMs, opendirectoryd holds records in memory and only writes stubs
+# on shutdown. Killing the daemon forces a clean flush before launchd
+# restarts it. This MUST run after every dscl/dseditgroup write above —
+# otherwise the changes (notably com.apple.access_ssh membership, which
+# PAM's pam_sacl requires for ssh logins) are lost when the VM is snapshotted.
+debug "Flushing opendirectoryd to persist user and group records..."
+sudo killall opendirectoryd
+until dscl . -list /Users &>/dev/null; do
+    sleep 0.5
+done
+sync
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Fix two independent bugs that together made `clod claude` / `clod shell` exit 255 immediately with no visible error on a freshly-built base VM + a host with a populated ssh-agent. The failures were invisible because `clod`'s ssh call uses `-q` and `|| true`.

### Bug 1 — `install.sh`: opendirectoryd flush ordered before SSH group write

`guest/install.sh` adds `clodpod` to `com.apple.access_ssh` (required by macOS PAM's `pam_sacl` to permit ssh logins), but the `killall opendirectoryd` flush ran *before* that `dseditgroup` call. In Tart VMs, opendirectoryd holds records in memory and only persists on shutdown/kill, so the group membership never reached disk and was lost when the base VM was snapshotted. Cloned VMs then rejected every ssh connection:

```
sshd-session: pam_sacl: denying 'clodpod' due to failed service ACL check
sshd-session: fatal: Access denied for user clodpod by PAM account configuration [preauth]
```

Only surfaces with `allow_sudo: false`. With sudo enabled, `clodpod` ends up in `admin`, which `com.apple.access_ssh` accepts via nested-group membership, masking the bug.

Fix: move the flush to after all `dscl` / `dseditgroup` writes, and add a comment pinning the ordering requirement.

### Bug 2 — `clod`: ssh didn't set `IdentitiesOnly=yes`

Both ssh invocations passed `-i \$SSH_KEYFILE_PRIV` but not `IdentitiesOnly=yes`, so ssh-agent's keys are offered first. On a host with ≥6 agent keys loaded, sshd's default `MaxAuthTries=6` closes the connection before the explicit clodpod key is ever tried:

```
Received disconnect from ... : Too many authentication failures
```

Fix: add `-o IdentitiesOnly=yes` to both ssh invocations.

## Test plan

- [x] Rebuild the base VM with `allow_sudo: false`; confirm `dseditgroup -o checkmember -m clodpod com.apple.access_ssh` reports `yes` inside a freshly cloned dst VM
- [x] `clod shell` connects successfully on a host with a loaded ssh-agent (≥6 keys)
- [x] `clod claude <project>` launches Claude in the VM instead of exiting 255
- [x] Existing test suite (`scripts/tests`) still passes (9/9, 2s)

## Notes / follow-ups (not in this PR)

- The `-q` + `|| true` on the ssh call swallowed the real error for both bugs. Worth reconsidering — at minimum, surfacing non-zero ssh exits would have made this a 30-second diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
