### PR TITLE
Fix unbound variable error in column existence checks

### DIFF
--- a/lib/db.sh
+++ b/lib/db.sh
@@ -21,6 +21,15 @@ migrate_db() {
     refresh_guest_home
 }
 
+# Check whether a column exists on a table. Uses grep's exit status directly
+# to avoid arithmetic-context evaluation of a non-numeric variable (which
+# breaks under `set -u` if the value happens to contain bare words).
+column_exists() {
+    local table="$1"
+    local column="$2"
+    sqlite3 "$DB_FILE" "PRAGMA table_info($table);" | grep -q "|$column|"
+}
+
 init_db() {
     debug "Creating $DB_FILE database..."
     sqlite3 "$DB_FILE" <<EOF
@@ -57,23 +66,17 @@ CREATE TABLE IF NOT EXISTS bases (
 EOF
 
     # Migration: add ram_mb column to existing instances tables
-    local has_ram_mb
-    has_ram_mb=$(sqlite3 "$DB_FILE" "PRAGMA table_info(instances);" | grep -c 'ram_mb') || true
-    if [[ "$has_ram_mb" -eq 0 ]]; then
+    if ! column_exists instances ram_mb; then
         sqlite3 "$DB_FILE" "ALTER TABLE instances ADD COLUMN ram_mb INTEGER;"
     fi
 
     # Migration: add base_name column to instances table
-    local has_base_name
-    has_base_name=$(sqlite3 "$DB_FILE" "PRAGMA table_info(instances);" | grep -c 'base_name') || true
-    if [[ "$has_base_name" -eq 0 ]]; then
+    if ! column_exists instances base_name; then
         sqlite3 "$DB_FILE" "ALTER TABLE instances ADD COLUMN base_name TEXT;"
     fi
 
     # Migration: add ssh_user column to instances table
-    local has_ssh_user
-    has_ssh_user=$(sqlite3 "$DB_FILE" "PRAGMA table_info(instances);" | grep -c 'ssh_user') || true
-    if [[ "$has_ssh_user" -eq 0 ]]; then
+    if ! column_exists instances ssh_user; then
         sqlite3 "$DB_FILE" "ALTER TABLE instances ADD COLUMN ssh_user TEXT;"
     fi
 }


### PR DESCRIPTION
## Summary

Fixes an `unbound variable` error that could occur during database migration when the column-existence checks in `init_db` received non-numeric input.

## Problem

The migration logic for adding `ram_mb`, `base_name`, and `ssh_user` columns used:

```bash
has_base_name=$(sqlite3 "$DB_FILE" "PRAGMA table_info(instances);" | grep -c 'base_name') || true
if [[ "$has_base_name" -eq 0 ]]; then
    ...
fi
```

The `-eq` operator evaluates both sides in **arithmetic context**, which treats bare words as variable names. If the captured value ever contained something non-numeric (e.g. a path like `/Users/...` leaking into the pipeline), bash would parse `Users` as a variable reference and — with `set -u` active — fail with:

```
db.sh: line 69: Users: unbound variable
```

The `|| true` fallback was also masking genuine `sqlite3` failures, letting migrations silently no-op.

## Fix

- Introduced a `column_exists` helper that relies on `grep -q`'s exit status, avoiding arithmetic context entirely.
- Anchored the grep pattern as `|column|` to match against pipe-delimited `PRAGMA table_info` output and prevent false matches on column name prefixes (e.g. `ram_mb` matching `ram_mb_limit`).
- Replaced all three `has_*` checks with `if ! column_exists instances <col>`.
- Removed the `|| true` fallbacks so real sqlite3 errors surface instead of being swallowed.

## Testing

- Fresh init on a new `$DB_FILE` — all three columns created as expected.
- Re-running against an already-migrated DB — no-ops cleanly, no errors.
- Running against a pre-migration DB missing all three columns — migrations apply correctly.
- Verified `set -u` no longer trips on the migration path.

## Risk

Low. Pure refactor of internal migration logic; no schema or API changes. The new helper is private to `db.sh`.