### PR TITLE
Add `clod clone-base` to fork a base profile via APFS CoW

### DIFF
--- a/clod
+++ b/clod
@@ -139,6 +139,12 @@ for arg in "$@"; do
             cmd_build_base "$@"
             exit 0
             ;;
+        clone-base)
+            while [[ "${1:-}" != "$arg" ]]; do shift; done
+            shift
+            cmd_clone_base "$@"
+            exit 0
+            ;;
         create|cr)
             while [[ "${1:-}" != "$arg" ]]; do shift; done
             shift

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -212,6 +212,89 @@ cmd_build_base() {
     build_base_vm "$profile"
 }
 
+# Clone an existing base profile into a new one via APFS copy-on-write.
+# Skips install.sh + interactive logins entirely — the new base inherits
+# everything baked into the source. Useful when the desired delta from the
+# source is something other than what install.sh provisions: a checkpoint
+# before risky changes, hand-edited config, recovery-mode tweaks, or any
+# other modification you'd rather hand-roll than re-derive from scratch.
+#
+# Whatever the user wants to change in the new base they do themselves
+# after the clone — this command just produces a bootable, registered
+# fork of the source.
+cmd_clone_base() {
+    local src=""
+    local dst=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                show_help_clone_base
+                exit 0
+                ;;
+            -*)
+                abort "Error: unknown clone-base option ($1)"
+                ;;
+            *)
+                if [[ -z "$src" ]]; then
+                    src="$1"
+                elif [[ -z "$dst" ]]; then
+                    dst="$1"
+                else
+                    abort "Usage: clod clone-base <src-profile> <dst-profile>"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "$src" && -n "$dst" ]] || abort "Usage: clod clone-base <src-profile> <dst-profile>"
+
+    # Validate names (same rule as --profile in build-base, prevents path
+    # traversal in the per-profile install-extra.sh dir and keeps tart VM
+    # names sane).
+    if [[ ! "$src" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*$ ]]; then
+        abort "Error: invalid source profile name ($src)"
+    fi
+    if [[ ! "$dst" =~ ^[a-zA-Z0-9][a-zA-Z0-9-]*$ ]]; then
+        abort "Error: invalid destination profile name ($dst)"
+    fi
+    [[ "$src" != "$dst" ]] || abort "Error: source and destination profiles must differ"
+
+    base_exists "$src" || abort "Error: source base profile not found ($src). Try: clod list"
+    ! base_exists "$dst" || abort "Error: destination base profile already exists ($dst)"
+
+    local src_vm dst_vm oci_source
+    src_vm="$(base_get_vm_name "$src")"
+    oci_source="$(base_get_oci_source "$src")"
+    dst_vm="clodpod-base-${dst}"
+
+    # Belt-and-braces: the bases row may be stale relative to tart's view
+    # (e.g. user manually deleted the VM). Verify the source VM actually
+    # exists and the dst VM name isn't already taken.
+    get_vm_exists "$src_vm" || abort "Error: source VM missing ($src_vm). Stored in bases but not in tart — clean up with 'sqlite3 \"$DB_FILE\" \"DELETE FROM bases WHERE name = ...\"'."
+    ! get_vm_exists "$dst_vm" || abort "Error: a tart VM named $dst_vm already exists"
+
+    # tart clone requires the source to be stopped. Don't auto-stop —
+    # could interrupt a session the user has live in the source base.
+    local src_state
+    src_state="$(get_vm_state "$src_vm")"
+    [[ "$src_state" == "stopped" ]] || abort "Error: source VM ($src_vm) must be stopped before cloning (current state: $src_state). Stop it via tart stop $src_vm or by exiting any live session."
+
+    info "Cloning base $src → $dst (APFS CoW; install.sh not re-run)"
+    clone_vm "$src_vm" "$dst_vm"
+    base_register "$dst" "$dst_vm" "$oci_source"
+
+    info "Base $dst registered."
+    info ""
+    info "Derive instances from it:"
+    info "  clod create <instance> --base $dst --dir ..."
+    info ""
+    info "To boot the new base directly (e.g. to inspect or modify it):"
+    info "  tart run $dst_vm              # normal boot"
+    info "  tart run --recovery $dst_vm   # recoveryOS (boot policy, csrutil, …)"
+}
+
 build_dst_vm() {
     [[ "${REBUILD_DST:-}" != "" ]] || return 0
 

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -61,6 +61,7 @@ Commands:
   create, cr        Create a named VM instance
   destroy           Delete a named VM instance
   build-base        Build or rebuild a base image
+  clone-base        Clone a base into a new profile (CoW, no install.sh)
   start             Start VM without connecting
   stop              Stop VM(s)
   set               Change VM settings
@@ -159,6 +160,47 @@ Examples:
 EOF
 }
 
+show_help_clone_base() {
+    cat <<'EOF'
+Usage: clod clone-base <src-profile> <dst-profile>
+
+Clone an existing base profile into a new one via APFS copy-on-write.
+No install.sh, no interactive logins — the new base inherits everything
+the source already has, and you make whatever changes you want directly
+in the new base afterwards.
+
+Use this when the desired delta from the source is something other than
+the install.sh pipeline: a checkpoint before risky modifications, a
+hand-edited variant, recovery-mode tweaks (custom boot policy, security
+settings), or anything else you'd rather hand-roll than re-derive. For
+variants whose delta is brew packages or new service logins, use
+'clod build-base --profile <name>' instead — those need install.sh to
+actually run.
+
+The source base must be stopped. The destination must not already exist
+(neither in the bases registry nor as a tart VM).
+
+After cloning, derive instances:
+  clod create <name> --base <dst-profile> --dir ...
+
+To boot the new base directly (to inspect it, edit files, or enter
+recoveryOS):
+  tart run clodpod-base-<dst-profile>              # normal boot
+  tart run --recovery clodpod-base-<dst-profile>   # recoveryOS
+
+Note on identity-bound state: tart applies --random-mac --random-serial
+when you later create instances from a base. State that's bound to the
+VM's serial number — most notably Apple Silicon LocalPolicy / boot
+policy — may not survive that re-serialization. If your modification to
+the new base depends on identity-bound state, you may end up needing to
+redo it per instance.
+
+Examples:
+  clod clone-base default checkpoint
+  clod clone-base default custom
+EOF
+}
+
 show_help_set() {
     cat <<'EOF'
 Usage: clod set <option> [args]
@@ -232,6 +274,7 @@ dispatch_help() {
         create|cr)          show_help_create ;;
         destroy)            show_help_destroy ;;
         build-base)         show_help_build_base ;;
+        clone-base)         show_help_clone_base ;;
         set)                show_help_set ;;
         shell|sh|s)         show_help_shell ;;
         stop)               show_help_stop ;;

--- a/lib/db.sh
+++ b/lib/db.sh
@@ -2,8 +2,13 @@
 # shellcheck disable=SC2154 # globals set by config.sh: DB_FILE, DATA_DIR, OLD_DB_FILE
 # Database operations: init, migrate, instance queries, settings
 
-# Escape single quotes for safe SQLite string literals: ' → ''
-sql_escape() { printf '%s' "${1//\'/\'\'}"; }
+# Escape single quotes for SQL string literals (doubles them, per the SQL standard).
+# The replacement is held in a variable on purpose: a literal "''" inside the
+# replacement of ${1//\'/''} is parsed as two adjacent empty strings on bash 4+
+# (so the apostrophe gets *deleted*), while a literal "\'\'" works on bash 4+
+# but emits the backslashes verbatim on bash 3.2. Routing through $q sidesteps
+# both quirks and works identically on bash 3.2 through 5.x.
+sql_escape() { local q="''"; printf '%s' "${1//\'/$q}"; }
 
 migrate_db() {
     if [[ -f "$DATA_DIR/clodpod.sqlite" ]]; then

--- a/lib/db.sh
+++ b/lib/db.sh
@@ -190,6 +190,11 @@ base_get_vm_name() {
     sqlite3 "$DB_FILE" "SELECT vm_name FROM bases WHERE name = '$(sql_escape "$name")' LIMIT 1;"
 }
 
+base_get_oci_source() {
+    local name="$1"
+    sqlite3 "$DB_FILE" "SELECT oci_source FROM bases WHERE name = '$(sql_escape "$name")' LIMIT 1;"
+}
+
 base_list() {
     sqlite3 -separator '|' "$DB_FILE" <<EOF
 SELECT name, vm_name, oci_source, created_at FROM bases ORDER BY created_at DESC;

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -23,6 +23,7 @@ Describe 'top-level help'
         When call show_help
         The output should include "create, cr"
         The output should include "build-base"
+        The output should include "clone-base"
         The output should include "shell, sh, s"
         The output should include "help, h"
     End
@@ -58,6 +59,14 @@ Describe 'per-command help'
         The output should include "--rebuild-oci"
         The output should include "--profile"
         The output should include "ALLOW_SUDO"
+    End
+
+    It 'show_help_clone_base shows usage and key requirements'
+        When call show_help_clone_base
+        The output should include "clod clone-base <src-profile> <dst-profile>"
+        The output should include "copy-on-write"
+        The output should include "stopped"
+        The output should include "--base"
     End
 
     It 'show_help_set shows all set options'


### PR DESCRIPTION
## Motivation

Today the only way to get a new layer-1 base is `clod build-base --profile <name>`, which always re-clones from the OCI VM and re-runs `install.sh` plus the interactive service-login step. That's the right thing when the variant's delta is brew packages or new tool logins, but it's overkill for variants whose only intended difference is a recovery-mode toggle (SIP off, custom boot policy) — anything that's a few MB of LocalPolicy/preboot changes on top of an already-provisioned base.

Concrete motivating case: a base with SIP disabled. Today users who want SIP off get there per-instance or by building a new base from the OCI template, which duplicates the blocks modified by install.sh.

## What this adds

`clod clone-base <src-profile> <dst-profile>` does just the clone + DB register:

- Validates profile names (same regex as `build-base --profile`)
- Refuses to overwrite (checks both the `bases` registry and the tart VM list)
- Requires the source VM to be stopped — no auto-stop, since that could interrupt a session running against the source base
- Reuses `clone_vm`, so the dst gets `--random-mac --random-serial` and the standard CPU count, matching every other clodpod clone path
- Inherits the source's `oci_source` string in the new `bases` row

## What this does *not* do

- Does not run `install.sh` or interactive login.
- No `clod destroy-base` yet — to undo, use `tart delete clodpod-base-<name>` and `sqlite3 \"$DB_FILE\" \"DELETE FROM bases WHERE name = '<name>';\"`. Worth a follow-up PR.

## Caveat surfaced in `--help`

tart applies `--random-mac --random-serial` when you later `clod create` instances from this base. Whether boot-policy changes (LocalPolicy on Apple Silicon) survive that re-serialization is unverified. If they don't, instance-level SIP state ends up reset and the user is back to per-instance toggling — which is exactly what they're already doing today. So this PR is at worst a no-op vs. status quo, at best skips the manual dance entirely. The help text says so explicitly.

## Drive-by fix: `sql_escape` (separate commit, splittable)

While running the test suite I hit a pre-existing failure on `db_spec.sh:8`. Investigating it turned up a cross-bash-version bug. The original `${1//\'/\'\'}` produced `it\'\'s` (literal backslashes in the SQL) on bash 3.2 because parameter-expansion replacement preserves backslashes there; bash 4+ strips them, so the same code silently did the right thing on modern bash. Read and write paths used the same broken function, so SQLite lookups symmetrically matched even when the value was corrupt — but anything stored in `instance_dirs.dir_path` or `settings.value` with a real apostrophe (e.g. a project at `~/Code/Bob's stuff/`) round-tripped wrong on 3.2.

The naive fix `${1//\'/''}` is *also* version-dependent the other way: bash 3.2 emits the literal `''`, but bash 4+ parses `''` inside the replacement as two adjacent empty strings and *deletes* the apostrophe entirely. Routing the replacement through a variable (`local q=\"''\"; …/\$q`) sidesteps both quirks.

Verified by running the full shellspec suite under both `/bin/bash` 3.2.57 and `/opt/homebrew/bin/bash` 5.3.9 — 33/33 on each. Without the fix, bash 3.2 fails 1/33 (the existing assertion) and bash 5+ would have fallen into the wrong half of the matrix had I shipped the naive fix.

Split into a separate commit so it can be reverted or moved to its own PR if you'd prefer.

## Tests

```
$ shellspec
.................................
Finished in 1.73 seconds (user 0.67 seconds, sys 0.86 seconds)
33 examples, 0 failures

$ shellspec --shell /opt/homebrew/bin/bash
33 examples, 0 failures
```

🤖 Generated by [Claude Opus 4.7](https://claude.com/claude-code), edited by echthesia