### PR TITLE
Add --forward-port for SSH reverse tunnels into VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ per-instance RAM and the total budget:
     clod set --vm-count default
 
 
+## Port forwarding
+
+Forward host ports into the VM via SSH reverse tunnels so VM agents can
+reach host resources such as databases and local LLMs.
+
+    clod --forward-port 8080 --forward-port 3000 claude
+    CLOD_FORWARD_PORTS=8080,3000 clod shell dev    # env var alternative
+
+Both methods can be combined.
+
+
 ## macOS versions
 
 By default ClodPod uses the `ghcr.io/cirruslabs/macos-tahoe-xcode:latest` VM flavor, but this is configurable by setting the MACOS_VERSION and MACOS_FLAVOR environment variables when building the VM:

--- a/clod
+++ b/clod
@@ -51,6 +51,7 @@ migrate_vm_names
 NO_GRAPHICS="${NO_GRAPHICS:-}"
 SHOULD_SELECT_PROJECT=true
 ALLOW_SUDO=
+FORWARD_PORTS=()
 _pre_args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -97,6 +98,12 @@ while [[ $# -gt 0 ]]; do
         -n|--no-select)
             SHOULD_SELECT_PROJECT=false
             shift
+            ;;
+        --forward-port)
+            [[ $# -ge 2 ]] || abort "Error: --forward-port requires a port number"
+            [[ "$2" =~ ^[0-9]+$ ]] || abort "Error: --forward-port requires a numeric port (got '$2')"
+            FORWARD_PORTS+=("$2")
+            shift 2
             ;;
         --)
             _pre_args+=("$@")

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -82,6 +82,7 @@ the updated packages. Recreate to pick up changes: clod destroy + create.
 
 Global options:
   --graphics/--no-graphics      VM display mode (default: graphics)
+  --forward-port PORT           Reverse-forward host port into VM (repeatable)
   --rebuild-oci                 Re-download OCI image (Layer 0)
   --rebuild-base                Rebuild base from OCI (Layer 1)
   --rebuild-dst                 Rebuild legacy VM home (Layer 2)
@@ -233,6 +234,7 @@ Arguments:
 Examples:
   clod shell dev
   clod shell dev --ram 12G
+  clod --forward-port 8080 shell dev
   clod shell dev -- claude --dangerously-skip-permissions
   clod shell                    # auto-selects if one instance exists
 EOF

--- a/lib/instance.sh
+++ b/lib/instance.sh
@@ -63,6 +63,17 @@ ssh_into_vm() {
 
     command_args_b64="$(encode_command_args)"
 
+    local forward_args=()
+    local port
+    for port in ${FORWARD_PORTS[@]+"${FORWARD_PORTS[@]}"}; do
+        forward_args+=("-R" "${port}:127.0.0.1:${port}")
+    done
+    if [[ -n "${CLOD_FORWARD_PORTS:-}" ]]; then
+        for port in ${CLOD_FORWARD_PORTS//,/ }; do
+            forward_args+=("-R" "${port}:127.0.0.1:${port}")
+        done
+    fi
+
     exec ssh \
         -q \
         -tt \
@@ -70,6 +81,7 @@ ssh_into_vm() {
         -o UserKnownHostsFile=/dev/null \
         -o IdentitiesOnly=yes \
         -i "$SSH_KEYFILE_PRIV" \
+        ${forward_args[@]+"${forward_args[@]}"} \
         "$ssh_user@$ipaddr" \
         /usr/bin/env \
             "TERM=xterm-256color" \


### PR DESCRIPTION
## Motivation

I run databases and local LLM servers on the host — no point bringing those into the VM. But I didn't want to expose additional network interfaces or deal with the hassle of configuring that, so SSH reverse tunnels are a nice easy option.

For high-traffic use cases, exposing a direct port between VM and host is better, but for local services the tunnel overhead is negligible.

## Changes

- `--forward-port PORT` global CLI option (repeatable) creates SSH reverse tunnels (`-R PORT:127.0.0.1:PORT`)
- `CLOD_FORWARD_PORTS` env var (comma-separated) as alternative — both can be combined
- Numeric port validation on CLI input
- Documented in `clod --help`, `clod help shell`, and README

## Usage

```bash
clod --forward-port 8080 --forward-port 3000 claude
CLOD_FORWARD_PORTS=8080,3000 clod shell dev
```