### PR TITLE
Add 'clod set --dir' and '--dir-remove' for mount management

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ or worktree branches. Each is a cheap APFS CoW clone of the base VM.
     # List named VMs
     clod list
 
+    # Add or replace a mount on an existing instance
+    clod set --dir data:/Volumes/data myproject
+
+    # Remove a mount
+    clod set --dir-remove data myproject
+
     # Clean up
     clod destroy myproject
     clod destroy --all

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -203,17 +203,25 @@ EOF
 
 show_help_set() {
     cat <<'EOF'
-Usage: clod set <option> [args]
+Usage: clod set [options] [NAME]
 
-Change VM and workspace settings.
+Change VM and workspace settings. Instance name is required for
+--ram, --dir, and --dir-remove. Options can be combined freely.
 
 Options:
-  --ram SIZE NAME       Set fixed RAM for an instance (e.g. 8G, 'default' to reset)
+  --ram SIZE            Set fixed RAM for an instance (e.g. 8G, 'default' to reset)
   --max-memory SIZE     Set workspace memory budget (e.g. 32G, 'default' for 5/8 host RAM)
   --vm-count N          Split budget across N VMs ('default' to reset to 1)
+  --dir name:path       Add or replace a mount on an existing instance
+  --dir-remove name     Remove a mount by name (primary mount cannot be removed)
+
+Mount changes take effect on next VM launch.
 
 Examples:
   clod set --ram 10G dev
+  clod set --dir code:/Users/me/src dev
+  clod set --dir code:/Users/me/src --ram 8G dev
+  clod set --dir-remove code dev
   clod set --max-memory 32G
   clod set --vm-count 3
 EOF

--- a/lib/instance.sh
+++ b/lib/instance.sh
@@ -451,19 +451,18 @@ vm_set() {
     local ram_name=""
     local max_memory_value=""
     local vm_count_value=""
+    local dir_value=""
+    local dir_name_target=""
+    local dir_remove_value=""
+    local dir_remove_target=""
 
+    local _instance_name=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --ram)
                 [[ $# -ge 2 ]] || abort "Usage: clod set --ram <size|default> <name>"
                 ram_value="$2"
                 shift 2
-                if [[ $# -ge 1 ]] && [[ "$1" != -* ]]; then
-                    ram_name="$1"
-                    shift
-                else
-                    abort "Usage: clod set --ram <size|default> <name>"
-                fi
                 ;;
             --max-memory)
                 [[ $# -ge 2 ]] || abort "Usage: clod set --max-memory <size|default>"
@@ -475,11 +474,89 @@ vm_set() {
                 vm_count_value="$2"
                 shift 2
                 ;;
-            *)
+            --dir)
+                [[ -z "$dir_value" && -z "$dir_remove_value" ]] || abort "Error: only one --dir operation allowed per command"
+                [[ $# -ge 2 ]] || abort "Usage: clod set --dir name:path <name>"
+                dir_value="$2"
+                shift 2
+                ;;
+            --dir-remove)
+                [[ -z "$dir_value" && -z "$dir_remove_value" ]] || abort "Error: only one --dir operation allowed per command"
+                [[ $# -ge 2 ]] || abort "Usage: clod set --dir-remove <dir_name> <name>"
+                dir_remove_value="$2"
+                shift 2
+                ;;
+            -*)
                 abort "Error: unknown set option ($1)"
+                ;;
+            *)
+                [[ -z "$_instance_name" ]] || abort "Error: multiple instance names ($1 vs $_instance_name)"
+                _instance_name="$1"
+                shift
                 ;;
         esac
     done
+
+    if [[ -n "$ram_value" ]] || [[ -n "$dir_value" ]] || [[ -n "$dir_remove_value" ]]; then
+        [[ -n "$_instance_name" ]] || abort "Error: instance name required"
+        ram_name="$_instance_name"
+        dir_name_target="$_instance_name"
+        dir_remove_target="$_instance_name"
+    fi
+
+    if [[ -n "$dir_value" ]]; then
+        vm_instance_exists "$dir_name_target" || abort "Error: instance not found ($dir_name_target)"
+
+        local parsed
+        parsed="$(parse_dir_spec "$dir_value")" || abort "Error: invalid --dir value ($dir_value)"
+
+        local dir_name="${parsed%%|*}"
+        local dir_path_spec="${parsed#*|}"
+
+        [[ "$dir_name" != "__install" ]] || abort "Error: reserved directory name (__install)"
+
+        local dir_path
+        dir_path="$(resolve_physical_path "$dir_path_spec" 2>/dev/null || true)"
+        [[ -d "$dir_path" ]] || abort "Error: directory not found ($dir_path_spec)"
+
+        local existing_primary
+        existing_primary="$(sqlite3 "$DB_FILE" "SELECT is_primary FROM instance_dirs WHERE instance_name = '$(sql_escape "$dir_name_target")' AND dir_name = '$(sql_escape "$dir_name")';")"
+        local is_primary="${existing_primary:-0}"
+        local existed=""
+        [[ -n "$existing_primary" ]] && existed="(replaced)"
+
+        sqlite3 "$DB_FILE" "INSERT OR REPLACE INTO instance_dirs (instance_name, dir_name, dir_path, is_primary) VALUES ('$(sql_escape "$dir_name_target")', '$(sql_escape "$dir_name")', '$(sql_escape "$dir_path")', $is_primary);" || abort "Error: failed to write mount to database"
+        info "Set --dir ${dir_name} for ${dir_name_target}${existed:+ $existed}"
+
+        local vm_name
+        vm_name="$(vm_get_instance_vm_name "$dir_name_target")"
+        if [[ -n "$vm_name" ]] && [[ "$(get_vm_state "$vm_name")" == "running" ]]; then
+            warn "Instance $dir_name_target is running — change takes effect on next launch"
+        fi
+    fi
+
+    if [[ -n "$dir_remove_value" ]]; then
+        vm_instance_exists "$dir_remove_target" || abort "Error: instance not found ($dir_remove_target)"
+
+        local row_primary
+        row_primary="$(sqlite3 "$DB_FILE" "SELECT is_primary FROM instance_dirs WHERE instance_name = '$(sql_escape "$dir_remove_target")' AND dir_name = '$(sql_escape "$dir_remove_value")';")"
+
+        if [[ -z "$row_primary" ]]; then
+            abort "Error: directory '$dir_remove_value' not found on $dir_remove_target"
+        else
+            if [[ "$row_primary" -eq 1 ]]; then
+                abort "Cannot remove primary directory '$dir_remove_value' from $dir_remove_target. Destroy and recreate the instance instead."
+            fi
+            sqlite3 "$DB_FILE" "DELETE FROM instance_dirs WHERE instance_name = '$(sql_escape "$dir_remove_target")' AND dir_name = '$(sql_escape "$dir_remove_value")';" || abort "Error: failed to remove mount from database"
+            info "Removed --dir ${dir_remove_value} from ${dir_remove_target}"
+
+            local vm_name
+            vm_name="$(vm_get_instance_vm_name "$dir_remove_target")"
+            if [[ -n "$vm_name" ]] && [[ "$(get_vm_state "$vm_name")" == "running" ]]; then
+                warn "Instance $dir_remove_target is running — change takes effect on next launch"
+            fi
+        fi
+    fi
 
     if [[ -n "$ram_value" ]]; then
         [[ -n "$ram_name" ]] || abort "Usage: clod set --ram <size|default> <name>"
@@ -550,8 +627,8 @@ vm_set() {
         fi
     fi
 
-    if [[ -z "$ram_value" ]] && [[ -z "$max_memory_value" ]] && [[ -z "$vm_count_value" ]]; then
-        abort "Usage: clod set [--ram <size|default> <name>] [--max-memory <size|default>] [--vm-count <N|default>]"
+    if [[ -z "$ram_value" ]] && [[ -z "$max_memory_value" ]] && [[ -z "$vm_count_value" ]] && [[ -z "$dir_value" ]] && [[ -z "$dir_remove_value" ]]; then
+        abort "Usage: clod set [options] [NAME]. Run 'clod help set' for details."
     fi
 }
 
@@ -678,14 +755,12 @@ vm_create() {
             --dir)
                 [[ $# -ge 2 ]] || abort "Error: --dir requires name:path"
 
-                local dir_spec="$2"
+                local parsed
+                parsed="$(parse_dir_spec "$2")" || abort "Error: invalid --dir value ($2)"
                 shift 2
 
-                [[ "$dir_spec" == *:* ]] || abort "Error: invalid --dir value ($dir_spec)"
-                local dir_name="${dir_spec%%:*}"
-                local dir_path_spec="${dir_spec#*:}"
-                [[ -n "$dir_name" ]] || abort "Error: missing directory name in --dir"
-                [[ -n "$dir_path_spec" ]] || abort "Error: missing directory path in --dir"
+                local dir_name="${parsed%%|*}"
+                local dir_path_spec="${parsed#*|}"
                 [[ "$dir_name" != "__install" ]] || abort "Error: reserved directory name (__install)"
                 if array_contains "$dir_name" ${dir_names[@]+"${dir_names[@]}"}; then
                     abort "Error: duplicate --dir name ($dir_name)"

--- a/lib/vm.sh
+++ b/lib/vm.sh
@@ -28,6 +28,16 @@ vm_validate_name() {
     fi
 }
 
+# Parse "name:path" → echoes "name|path", exit 1 on invalid input.
+parse_dir_spec() {
+    local spec="$1"
+    [[ "$spec" == *:* ]] || return 1
+    local name="${spec%%:*}"
+    local path="${spec#*:}"
+    [[ -n "$name" && -n "$path" ]] || return 1
+    printf '%s|%s\n' "$name" "$path"
+}
+
 parse_ram_size() {
     local input="${1:-}"
     local value

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -71,7 +71,7 @@ Describe 'per-command help'
 
     It 'show_help_set shows all set options'
         When call show_help_set
-        The output should include "--ram SIZE NAME"
+        The output should include "--ram SIZE"
         The output should include "--max-memory"
         The output should include "--vm-count"
     End

--- a/spec/set_dir_spec.sh
+++ b/spec/set_dir_spec.sh
@@ -1,0 +1,125 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154 # TEST_TMPDIR set by spec_helper.sh
+
+Describe 'clod set --dir / --dir-remove'
+    Include lib/common.sh
+    Include lib/db.sh
+    Include lib/vm.sh
+    Include lib/instance.sh
+
+    setup_db() {
+        DB_FILE="$TEST_TMPDIR/test.sqlite"
+        init_db
+        sqlite3 "$DB_FILE" "INSERT INTO instances (name, vm_name) VALUES ('dev', 'clodpod-dev');"
+        sqlite3 "$DB_FILE" "INSERT INTO instance_dirs (instance_name, dir_name, dir_path, is_primary) VALUES ('dev', 'project', '/tmp', 1);"
+
+        mkdir -p "$TEST_TMPDIR/srcdir"
+        RESOLVED_TMPDIR="$(cd -P "$TEST_TMPDIR" && pwd -P)"
+    }
+    BeforeEach 'setup_db'
+
+    vm_get_instance_vm_name() { echo "clodpod-$1"; }
+    get_vm_state() { echo "stopped"; }
+
+    Describe 'add new directory'
+        It 'inserts new mount'
+            When call vm_set --dir "code:$TEST_TMPDIR/srcdir" dev
+            row=$(sqlite3 "$DB_FILE" "SELECT dir_path, is_primary FROM instance_dirs WHERE instance_name='dev' AND dir_name='code';")
+            The status should be success
+            The variable row should not be blank
+            The stderr should include "Set --dir code"
+        End
+
+        It 'rejects __install reserved name'
+            When run vm_set --dir "__install:$TEST_TMPDIR/srcdir" dev
+            The status should be failure
+            The stderr should include "reserved"
+        End
+
+        It 'rejects nonexistent directory'
+            When run vm_set --dir "code:/this/does/not/exist" dev
+            The status should be failure
+            The stderr should include "directory not found"
+        End
+
+        It 'rejects nonexistent instance'
+            When run vm_set --dir "code:$TEST_TMPDIR/srcdir" ghost
+            The status should be failure
+            The stderr should include "instance not found"
+        End
+    End
+
+    Describe 'replace existing directory'
+        It 'updates path of existing mount'
+            mkdir -p "$TEST_TMPDIR/newpath"
+            vm_set --dir "project:$TEST_TMPDIR/newpath" dev 2>/dev/null
+            path=$(sqlite3 "$DB_FILE" "SELECT dir_path FROM instance_dirs WHERE instance_name='dev' AND dir_name='project';")
+            When call echo "$path"
+            The output should eq "$RESOLVED_TMPDIR/newpath"
+        End
+
+        It 'preserves is_primary on replace'
+            mkdir -p "$TEST_TMPDIR/newpath"
+            vm_set --dir "project:$TEST_TMPDIR/newpath" dev 2>/dev/null
+            primary=$(sqlite3 "$DB_FILE" "SELECT is_primary FROM instance_dirs WHERE instance_name='dev' AND dir_name='project';")
+            When call echo "$primary"
+            The output should eq "1"
+        End
+
+        It 'prints (replaced) suffix'
+            When call vm_set --dir "project:$TEST_TMPDIR/srcdir" dev
+            The stderr should include "(replaced)"
+        End
+    End
+
+    Describe '--dir-remove'
+        setup_secondary() {
+            sqlite3 "$DB_FILE" "INSERT INTO instance_dirs (instance_name, dir_name, dir_path, is_primary) VALUES ('dev', 'extra', '/tmp', 0);"
+        }
+        Before 'setup_secondary'
+
+        It 'removes non-primary directory'
+            vm_set --dir-remove extra dev 2>/dev/null
+            count=$(sqlite3 "$DB_FILE" "SELECT COUNT(*) FROM instance_dirs WHERE instance_name='dev' AND dir_name='extra';")
+            When call echo "$count"
+            The output should eq "0"
+        End
+
+        It 'prints Removed info'
+            When call vm_set --dir-remove extra dev
+            The stderr should include "Removed --dir extra"
+        End
+
+        It 'rejects removing primary'
+            When run vm_set --dir-remove project dev
+            The status should be failure
+            The stderr should include "Cannot remove primary"
+        End
+
+        It 'rejects nonexistent mount name'
+            When run vm_set --dir-remove nonexistent dev
+            The status should be failure
+            The stderr should include "not found"
+        End
+
+        It 'rejects nonexistent instance'
+            When run vm_set --dir-remove extra ghost
+            The status should be failure
+            The stderr should include "instance not found"
+        End
+    End
+
+    Describe 'multi-flag rejection'
+        It 'rejects two --dir flags'
+            When run vm_set --dir "a:$TEST_TMPDIR/srcdir" dev --dir "b:$TEST_TMPDIR/srcdir" dev
+            The status should be failure
+            The stderr should include "only one --dir operation"
+        End
+
+        It 'rejects --dir mixed with --dir-remove'
+            When run vm_set --dir "a:$TEST_TMPDIR/srcdir" dev --dir-remove b dev
+            The status should be failure
+            The stderr should include "only one --dir operation"
+        End
+    End
+End

--- a/spec/vm_spec.sh
+++ b/spec/vm_spec.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+
+Describe 'lib/vm.sh'
+    Include lib/common.sh
+    Include lib/vm.sh
+
+    Describe 'parse_dir_spec'
+        It 'parses name:path'
+            When call parse_dir_spec "code:/Users/me/src"
+            The output should eq "code|/Users/me/src"
+        End
+
+        It 'preserves : in path'
+            When call parse_dir_spec "code:/foo:bar/baz"
+            The output should eq "code|/foo:bar/baz"
+        End
+
+        It 'rejects missing colon'
+            When call parse_dir_spec "noslash"
+            The status should be failure
+        End
+
+        It 'rejects empty input'
+            When call parse_dir_spec ""
+            The status should be failure
+        End
+
+        It 'rejects missing name'
+            When call parse_dir_spec ":/path"
+            The status should be failure
+        End
+
+        It 'rejects missing path'
+            When call parse_dir_spec "name:"
+            The status should be failure
+        End
+    End
+End


### PR DESCRIPTION
## Summary

Change mounts on existing instances without destroy+recreate.

`clod set --dir code:/path dev` adds or replaces a mount,
`clod set --dir-remove code dev` removes one. Both are repeatable
and compose with each other and `--ram`. Mixed ops execute in CLI order.

## Details

Instance name is a shared positional instead of per-flag.
`parse_dir_spec` extracted and shared with `vm_create`.
Primary directory can be replaced but not removed.

`|` and newline are rejected in names and paths. Both are legal on
macOS but the internal format uses `|` as delimiter. Supporting them
is doable but a separate job. sqlite3 writes are guarded with
`|| abort` so a locked or full database doesn't silently succeed.

Same spirit as the input hardening in #51, though the security framing
there doesn't quite apply since `clod` runs on the host with full
host access.

27 new tests, 61 total pass under bash 3.2.

## Tests

- [x] 61/61 specs pass under bash 3.2 (`/bin/bash`)
- [x] Manual: add, replace, remove, combined with `--ram`
- [x] Manual: verify mount visible inside VM, removed mount gone after restart