### PR TITLE
Add per-project `Brewfile` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ Optional virtual machine configuration (example):
 
 To add custom configuration; see `./guest/home/README.md`.
 
+### Per-project Homebrew dependencies (Brewfile)
+
+If a mounted project contains a [Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile) at its root, ClodPod will reconcile it via `brew bundle` automatically:
+
+- **At instance creation** (`clod create`): every mounted project's Brewfile is applied.
+- **At every shell entry** (`clod claude`, `clod shell`, etc.): the active project's Brewfile is checked with `brew bundle check`; install only runs on drift, so steady-state cost is negligible.
+
+The default file is `./Brewfile`; override per-session by setting the standard `HOMEBREW_BUNDLE_FILE` env var. Install uses `--no-upgrade`, so pinned versions stay pinned. Failures emit a loud warning but never block the VM or shell from starting. ClodPod does not run `brew bundle cleanup` — removal stays a manual call.
+
 
 # Background
 

--- a/guest/configure.sh
+++ b/guest/configure.sh
@@ -85,6 +85,22 @@ sudo chown -R "admin:staff" "$(brew --prefix)"
 
 
 ###############################################################################
+# Apply project Brewfiles
+# Project mounts surface under /Volumes/My Shared Files/<name>. Each project
+# may ship a ./Brewfile; we reconcile it via 'brew bundle'. Failures warn
+# but never abort — a broken Brewfile must not stop the instance coming up.
+###############################################################################
+BREWFILE_LIB="/Users/admin/lib/brewfile.sh"
+SHARED_MOUNTS="/Volumes/My Shared Files"
+if [[ -f "$BREWFILE_LIB" ]] && [[ -d "$SHARED_MOUNTS" ]]; then
+    debug "Applying project Brewfiles..."
+    # shellcheck source=guest/home/lib/brewfile.sh
+    source "$BREWFILE_LIB"
+    apply_all_project_brewfiles "$SHARED_MOUNTS"
+fi
+
+
+###############################################################################
 # Finalize sudo configuration
 # configure.sh is the final authority on sudo state per-instance.
 # This handles base->instance inheritance: a base built with ALLOW_SUDO=true

--- a/guest/home/.zshrc
+++ b/guest/home/.zshrc
@@ -102,6 +102,12 @@ PROJECT="${PROJECT:-project}"
 PROJECT_DIR="$HOME/projects/$PROJECT"
 if [[ -d "$PROJECT_DIR" ]]; then
     cd "$PROJECT_DIR"
+    # Reconcile this project's Brewfile (cheap when satisfied; self-heals
+    # when the user adds the project via 'clod set --dir' or edits Brewfile).
+    if [[ -f "$HOME/lib/brewfile.sh" ]]; then
+        source "$HOME/lib/brewfile.sh"
+        apply_brewfile_if_present "$PROJECT_DIR"
+    fi
     # If INITIAL_DIR is set, navigate to the subdirectory within the project
     if [[ -n "${INITIAL_DIR:-}" ]] && [[ -d "$PROJECT_DIR/$INITIAL_DIR" ]]; then
         cd "$PROJECT_DIR/$INITIAL_DIR"
@@ -121,3 +127,4 @@ if [[ "${COMMAND:-}" != "" ]]; then
 elif [[ ${#command_args[@]} -gt 0 ]]; then
     exec "${command_args[@]}"
 fi
+

--- a/guest/home/README.md
+++ b/guest/home/README.md
@@ -20,3 +20,42 @@ To speed up building virtual machines, this project creates a base image that co
 If you add or modify config files in the `user` directory, rebuild the destination image with `clod --rebuild-dst`. Because this builds from the base image it's a fast operation.
 
 If there are extensive changes to (brew) software packages, you can rebuild the base image with `clod --rebuild-base` to speed up future rebuilds.
+
+
+## Per-project Homebrew dependencies (Brewfile)
+
+Each mounted project can declare its own Homebrew dependencies in a [Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile) at the project root. Example:
+
+    # ./Brewfile
+    brew "jq"
+    brew "rg"
+    cask "graphviz"
+
+ClodPod reconciles project Brewfiles at two moments:
+
+1. **Instance creation** (`clod create`) — every project mounted into the new instance has its Brewfile applied as part of `configure.sh`.
+2. **Shell entry** (`clod claude`, `clod shell`, `clod codex`, etc.) — `.zshrc` runs `brew bundle check` on the active project's Brewfile. If everything is satisfied, nothing happens; if drift is detected, `brew bundle install --no-upgrade` runs to reconcile.
+
+This means:
+
+- Projects added to a running instance via `clod set --dir name:path` pick up their Brewfile on the next shell entry — no rebuild required.
+- Editing a project's Brewfile takes effect the next time you open a shell into that project.
+- Steady-state cost is one `brew bundle check` per shell — fast.
+
+### Path resolution
+
+The default file is `./Brewfile` (at the project root). To override per session, set Homebrew's standard env var:
+
+    HOMEBREW_BUNDLE_FILE=/path/to/Custom.brewfile clod claude my-project
+
+The override only applies to single-project flows; instance-creation iterates each mounted project's own `./Brewfile`.
+
+### Failure mode
+
+A failing `brew bundle install` emits a loud `WARNING:` on stderr but never aborts the shell or instance creation. A broken Brewfile must not prevent you from getting into the VM to fix it.
+
+### What ClodPod does *not* do
+
+- No `brew bundle cleanup` — packages you installed manually inside the VM stay put. Pruning is your call.
+- No `--upgrade` — pinned versions stay pinned. Run `brew upgrade` yourself when you want it.
+- No `brew update` per-shell — that's part of base image build.

--- a/guest/home/lib/brewfile.sh
+++ b/guest/home/lib/brewfile.sh
@@ -1,0 +1,62 @@
+# shellcheck shell=bash
+#
+# Apply project Brewfiles via 'brew bundle'.
+#
+# Two entry points:
+#   apply_brewfile_if_present <project_dir>
+#       Resolve the active Brewfile (HOMEBREW_BUNDLE_FILE override, else
+#       <project_dir>/Brewfile) and reconcile. Intended for per-shell entry.
+#
+#   apply_all_project_brewfiles <projects_root>
+#       Walk each project subdir and reconcile its own Brewfile. The env
+#       override is intentionally ignored here — it cannot mean anything
+#       sensible across multiple projects. Intended for instance creation.
+#
+# Reconciliation is `brew bundle check` first; `install --no-upgrade` only
+# runs on drift. Failures emit a loud warning to stderr but never abort —
+# a broken Brewfile must not block the shell or instance from coming up.
+
+# Reconcile a single resolved Brewfile path. Private helper.
+_reconcile_brewfile() {
+    local brewfile="$1"
+
+    if ! command -v brew >/dev/null 2>&1; then
+        printf 'WARNING: brew not found on PATH; skipping %s\n' "$brewfile" >&2
+        return 0
+    fi
+
+    if brew bundle check --no-upgrade --file="$brewfile" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    printf 'clodpod: applying %s\n' "$brewfile" >&2
+    if ! brew bundle install --no-upgrade --file="$brewfile"; then
+        printf 'WARNING: brew bundle install failed for %s — continuing\n' "$brewfile" >&2
+    fi
+    return 0
+}
+
+apply_brewfile_if_present() {
+    local project_dir="$1"
+    local brewfile="${HOMEBREW_BUNDLE_FILE:-$project_dir/Brewfile}"
+
+    [[ -f "$brewfile" ]] || return 0
+    _reconcile_brewfile "$brewfile"
+}
+
+apply_all_project_brewfiles() {
+    local projects_root="$1"
+
+    [[ -d "$projects_root" ]] || return 0
+
+    local project_dir brewfile
+    for project_dir in "$projects_root"/*; do
+        [[ -d "$project_dir" ]] || continue
+        # __install is the clodpod payload mount, not a project.
+        [[ "$(basename "$project_dir")" == "__install" ]] && continue
+        brewfile="$project_dir/Brewfile"
+        [[ -f "$brewfile" ]] || continue
+        _reconcile_brewfile "$brewfile"
+    done
+    return 0
+}

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -119,6 +119,9 @@ Examples:
   clod create dev --dir project:/Users/me/src/app
   clod create dev --ram 8G --base custom --dir work:$(pwd)
   clod create worker --dir repo:$(pwd) --dir data:/Volumes/data
+
+Project Brewfiles (./Brewfile) are applied automatically at instance
+creation, and re-checked on each shell entry. See guest/home/README.md.
 EOF
 }
 

--- a/spec/brewfile_spec.sh
+++ b/spec/brewfile_spec.sh
@@ -1,0 +1,165 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154 # TEST_TMPDIR set by spec_helper.sh
+
+Describe 'guest/home/lib/brewfile.sh'
+    Include guest/home/lib/brewfile.sh
+
+    setup_brew_mock() {
+        export BREW_LOG="$TEST_TMPDIR/brew.log"
+        export BREW_CHECK_EXIT=0
+        export BREW_INSTALL_EXIT=0
+        : > "$BREW_LOG"
+    }
+    BeforeEach 'setup_brew_mock'
+
+    # Mock 'brew' as a shell function. Records invocations to BREW_LOG and
+    # returns a configurable exit code per subcommand. Function definitions
+    # shadow PATH lookups, so the lib's 'brew ...' calls hit this instead.
+    brew() {
+        echo "brew $*" >> "$BREW_LOG"
+        if [[ "$1" == "bundle" && "$2" == "check" ]]; then
+            return "$BREW_CHECK_EXIT"
+        fi
+        if [[ "$1" == "bundle" && "$2" == "install" ]]; then
+            return "$BREW_INSTALL_EXIT"
+        fi
+        return 0
+    }
+
+    make_project() {
+        local dir="$1"
+        mkdir -p "$dir"
+        if [[ $# -ge 2 ]]; then
+            printf '%s\n' "$2" > "$dir/Brewfile"
+        fi
+    }
+
+    Describe 'apply_brewfile_if_present'
+        It 'no-ops when no Brewfile present'
+            make_project "$TEST_TMPDIR/proj"
+            When call apply_brewfile_if_present "$TEST_TMPDIR/proj"
+            The status should be success
+            The contents of file "$BREW_LOG" should equal ""
+        End
+
+        It 'runs install when check reports drift'
+            make_project "$TEST_TMPDIR/proj" 'brew "jq"'
+            BREW_CHECK_EXIT=1
+            When call apply_brewfile_if_present "$TEST_TMPDIR/proj"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "bundle check"
+            The contents of file "$BREW_LOG" should include "bundle install"
+            The contents of file "$BREW_LOG" should include "--no-upgrade"
+            The contents of file "$BREW_LOG" should include "$TEST_TMPDIR/proj/Brewfile"
+            The stderr should include "applying"
+        End
+
+        It 'skips install when check passes'
+            make_project "$TEST_TMPDIR/proj" 'brew "jq"'
+            BREW_CHECK_EXIT=0
+            When call apply_brewfile_if_present "$TEST_TMPDIR/proj"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "bundle check"
+            The contents of file "$BREW_LOG" should not include "bundle install"
+        End
+
+        It 'honors HOMEBREW_BUNDLE_FILE override'
+            make_project "$TEST_TMPDIR/proj"   # no Brewfile in project
+            mkdir -p "$TEST_TMPDIR/elsewhere"
+            printf '%s\n' 'brew "jq"' > "$TEST_TMPDIR/elsewhere/Custom.brewfile"
+            export HOMEBREW_BUNDLE_FILE="$TEST_TMPDIR/elsewhere/Custom.brewfile"
+            BREW_CHECK_EXIT=1
+            When call apply_brewfile_if_present "$TEST_TMPDIR/proj"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "$TEST_TMPDIR/elsewhere/Custom.brewfile"
+            The contents of file "$BREW_LOG" should not include "$TEST_TMPDIR/proj/Brewfile"
+            The stderr should include "applying"
+        End
+
+        It 'warns loudly but returns 0 when install fails'
+            make_project "$TEST_TMPDIR/proj" 'brew "jq"'
+            BREW_CHECK_EXIT=1
+            BREW_INSTALL_EXIT=1
+            When call apply_brewfile_if_present "$TEST_TMPDIR/proj"
+            The status should be success
+            The stderr should include "WARNING"
+            The stderr should include "$TEST_TMPDIR/proj/Brewfile"
+        End
+
+        It 'returns 0 with a warning when brew is missing'
+            make_project "$TEST_TMPDIR/proj" 'brew "jq"'
+            unset -f brew
+            PATH="/usr/bin:/bin"
+            When call apply_brewfile_if_present "$TEST_TMPDIR/proj"
+            The status should be success
+            The stderr should include "WARNING"
+            The stderr should include "brew"
+        End
+    End
+
+    Describe 'apply_all_project_brewfiles'
+        It 'iterates each project subdir with a Brewfile'
+            mkdir -p "$TEST_TMPDIR/projects"
+            make_project "$TEST_TMPDIR/projects/alpha" 'brew "jq"'
+            make_project "$TEST_TMPDIR/projects/beta"   # no Brewfile
+            make_project "$TEST_TMPDIR/projects/gamma" 'brew "rg"'
+            BREW_CHECK_EXIT=1
+            When call apply_all_project_brewfiles "$TEST_TMPDIR/projects"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "alpha/Brewfile"
+            The contents of file "$BREW_LOG" should include "gamma/Brewfile"
+            The contents of file "$BREW_LOG" should not include "beta/Brewfile"
+            The stderr should include "applying"
+        End
+
+        It 'continues to remaining projects after one fails'
+            mkdir -p "$TEST_TMPDIR/projects"
+            make_project "$TEST_TMPDIR/projects/alpha" 'brew "jq"'
+            make_project "$TEST_TMPDIR/projects/beta"  'brew "rg"'
+            BREW_CHECK_EXIT=1
+            BREW_INSTALL_EXIT=1
+            When call apply_all_project_brewfiles "$TEST_TMPDIR/projects"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "alpha/Brewfile"
+            The contents of file "$BREW_LOG" should include "beta/Brewfile"
+            The stderr should include "WARNING"
+        End
+
+        It 'handles empty projects root gracefully'
+            mkdir -p "$TEST_TMPDIR/projects"
+            When call apply_all_project_brewfiles "$TEST_TMPDIR/projects"
+            The status should be success
+            The contents of file "$BREW_LOG" should equal ""
+        End
+
+        It 'ignores non-directory entries in projects root'
+            mkdir -p "$TEST_TMPDIR/projects"
+            make_project "$TEST_TMPDIR/projects/alpha" 'brew "jq"'
+            : > "$TEST_TMPDIR/projects/stray-file"
+            BREW_CHECK_EXIT=1
+            When call apply_all_project_brewfiles "$TEST_TMPDIR/projects"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "alpha/Brewfile"
+            The contents of file "$BREW_LOG" should not include "stray-file"
+            The stderr should include "applying"
+        End
+
+        It 'skips the __install reserved mount'
+            mkdir -p "$TEST_TMPDIR/projects"
+            make_project "$TEST_TMPDIR/projects/alpha"    'brew "jq"'
+            make_project "$TEST_TMPDIR/projects/__install" 'brew "rg"'
+            BREW_CHECK_EXIT=1
+            When call apply_all_project_brewfiles "$TEST_TMPDIR/projects"
+            The status should be success
+            The contents of file "$BREW_LOG" should include "alpha/Brewfile"
+            The contents of file "$BREW_LOG" should not include "__install/Brewfile"
+            The stderr should include "applying"
+        End
+
+        It 'handles missing projects root gracefully'
+            When call apply_all_project_brewfiles "$TEST_TMPDIR/does-not-exist"
+            The status should be success
+            The contents of file "$BREW_LOG" should equal ""
+        End
+    End
+End


### PR DESCRIPTION
I have a few projects that have their own needed Homebrew dependencies (on top of the ones `clodpod` needs itself).  every time I've had to rebuild the image, I was forced to re-install these manually.  

TIL (far too late) is that Homebrew supports a `Brewfile` for projects to define dependencies.  This change to `clodpod` integrates it by checking the mounted projects for the `Brewfile` and auto-installing them for you.

I wondered if `clodpod`s own Homebrew dependencies might be best represented this way as well, but I left that one for now.