### PR TITLE
Add CI workflow and auto-tag job

### DIFF
--- a/.github/scripts/tag-version
+++ b/.github/scripts/tag-version
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Tag the current version if it hasn't been tagged yet.
+# Called by CI after a successful build on the default branch.
+# Exits 0 (no-op) if the tag already exists — this is the normal case
+# when a push doesn't change the version.
+set -Eeuo pipefail
+trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Note: branch guard is handled by the CI workflow (github.ref == 'refs/heads/main').
+# Do not duplicate it here — detached-HEAD checkouts in CI break git-based detection.
+
+# --- Read current version ---
+CURRENT_VERSION=$(awk -F'"' '/^[[:space:]]*VERSION="[0-9.]*"/ {print $2; exit}' ./lib/config.sh)
+if [[ -z "$CURRENT_VERSION" ]]; then
+  echo >&2 "Error: Could not parse version from lib/config.sh"
+  exit 1
+fi
+
+TAG_NAME="v$CURRENT_VERSION"
+
+# --- No-op if already tagged ---
+if git rev-parse -q --verify "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
+  echo "Tag $TAG_NAME already exists — nothing to do."
+  exit 0
+fi
+
+# --- Create and push the tag on HEAD (the merge commit) ---
+echo "Tagging $TAG_NAME on $(git rev-parse --short HEAD)"
+git config user.name  "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git tag -a "$TAG_NAME" -m "Version $CURRENT_VERSION"
+git push origin "$TAG_NAME"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install bash and shellspec
+        run: brew install bash shellspec
+
+      - name: Run tests
+        env:
+          VERBOSE: 1
+        run: ./scripts/validate
+
+  tag-version:
+    name: Tag Version
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.CLODPOD_TAG_TOKEN }}
+
+      - name: Tag version if updated
+        run: .github/scripts/tag-version


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — `Tests` job on `macos-latest` runs `./scripts/validate` (both `scripts/tests` and `shellspec`) on PRs and pushes to main.
- Adds `tag-version` job + `.github/scripts/tag-version` — on push to main, creates `v<VERSION>` tag from `lib/config.sh` if missing. Uses `secrets.CLODPOD_TAG_TOKEN` (fine-grained PAT, Contents: write) to push past admin-enforced branch protection.
- Pairs with branch protection on `main` (already enabled out-of-band): required `Tests` check, dismiss stale reviews, enforce admins, no force-push, no deletion.

## Test plan
- [ ] CI runs on this PR and `Tests` passes on macos-latest
- [ ] After merge, `tag-version` job creates `v1.0.24` tag (or no-ops if already present)
- [ ] Confirm next `scripts/bump-version` cycle still works end-to-end