### PR TITLE
Add optional project isolation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ or worktree branches. Each is a cheap APFS CoW clone of the base VM.
     clod destroy myproject
     clod destroy --all
 
+## Project isolation
+
+By default the shared VM mounts every registered project, so agents can see
+all of them. Enable isolation to mount only the active project; other
+projects stay registered but are not visible inside the VM. Switching
+projects then requires a VM restart (you'll be prompted on next connect).
+
+    # Mount only the active project in the default VM
+    clod set --isolation on
+
+    # Restore mounting all projects
+    clod set --isolation off
+
+For full isolation including VM state, use named VM instances (above) —
+they only ever mount their own directories.
+
 ## Memory budget
 
 By default, VMs share a memory budget of 5/8 of host RAM. You can configure

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -215,6 +215,8 @@ Options:
   --ram SIZE            Set fixed RAM for an instance (e.g. 8G, 'default' to reset)
   --max-memory SIZE     Set workspace memory budget (e.g. 32G, 'default' for 5/8 host RAM)
   --vm-count N          Split budget across N VMs ('default' to reset to 1)
+  --isolation on|off    Mount only the active project in the default 'xcode' VM
+                        ('off' restores mounting all projects)
   --dir name:path       Add or replace a mount on an existing instance
   --dir-remove name     Remove a mount by name (primary mount cannot be removed)
 
@@ -222,6 +224,7 @@ Mount changes take effect on next VM launch.
 
 Examples:
   clod set --ram 10G dev
+  clod set --isolation on
   clod set --dir code:/Users/me/src dev
   clod set --dir code:/Users/me/src --ram 8G dev
   clod set --dir-remove code dev

--- a/lib/db.sh
+++ b/lib/db.sh
@@ -141,8 +141,15 @@ vm_get_instance_dirs() {
     local instance_name="$1"
     # The 'xcode' instance is the unified successor to the legacy DST VM:
     # its mounts come from the projects table at launch time, not instance_dirs.
-    # Primary is the most-recently-added/selected project.
+    # Primary is the most-recently-added/selected project. With isolation
+    # enabled, only the primary project is mounted.
     if [[ "$instance_name" == "xcode" ]]; then
+        if [[ "$(get_setting "isolate_projects" "false")" == "true" ]]; then
+            sqlite3 -separator '|' "$DB_FILE" <<EOF
+SELECT name, path, 1 FROM projects ORDER BY date_added DESC LIMIT 1;
+EOF
+            return 0
+        fi
         sqlite3 -separator '|' "$DB_FILE" <<EOF
 SELECT name, path,
        CASE WHEN rowid = (SELECT rowid FROM projects ORDER BY date_added DESC LIMIT 1)

--- a/lib/instance.sh
+++ b/lib/instance.sh
@@ -241,21 +241,21 @@ vm_shell() {
             current_ram="$(tart get "$vm_name" --format json | jq '.Memory' 2>/dev/null || echo "?")"
             warn "$instance_name is already running with ${current_ram} MB RAM. --ram override ignored for running VM."
         fi
-        # xcode reads dirs from the projects table; new projects need a restart
-        # to be mounted. Mirrors the legacy `check_projects_active` UX.
+        # xcode reads dirs from the projects table; mount changes (new project,
+        # or a different active project under isolation) need a restart.
         if [[ "$instance_name" == "xcode" ]] && ! check_projects_active; then
-            warn "New project directory added; virtual machine restart required"
+            warn "Project mounts changed; virtual machine restart required"
             read -p "$vm_name is running; restart it? (y/N)" -n 1 -r response
             echo
             if [[ "$response" =~ ^[Yy]$ ]]; then
                 stop_vm "$vm_name"
                 vm_run "$vm_name" "$effective_ram" "$vm_name" ${dir_args[@]+"${dir_args[@]}"} || true
-                [[ "$instance_name" == "xcode" ]] && sqlite3 "$DB_FILE" "UPDATE projects SET active = 1;"
+                [[ "$instance_name" == "xcode" ]] && mark_projects_active
             fi
         fi
     else
         vm_run "$vm_name" "$effective_ram" "$vm_name" ${dir_args[@]+"${dir_args[@]}"} || true
-        [[ "$instance_name" == "xcode" ]] && sqlite3 "$DB_FILE" "UPDATE projects SET active = 1;"
+        [[ "$instance_name" == "xcode" ]] && mark_projects_active
     fi
 
     local ssh_user
@@ -333,7 +333,7 @@ vm_start_instance() {
 
     info "Starting instance $instance_name ($vm_name)"
     vm_run "$vm_name" "$effective_ram" "$vm_name" ${dir_args[@]+"${dir_args[@]}"} || true
-    [[ "$instance_name" == "xcode" ]] && sqlite3 "$DB_FILE" "UPDATE projects SET active = 1;"
+    [[ "$instance_name" == "xcode" ]] && mark_projects_active
 }
 
 # Auto-select target by name, by sole instance, or abort. Mirrors the policy
@@ -451,6 +451,7 @@ vm_set() {
     local ram_name=""
     local max_memory_value=""
     local vm_count_value=""
+    local isolation_value=""
     local dir_value=""
     local dir_name_target=""
     local dir_remove_value=""
@@ -472,6 +473,11 @@ vm_set() {
             --vm-count)
                 [[ $# -ge 2 ]] || abort "Usage: clod set --vm-count <N|default>"
                 vm_count_value="$2"
+                shift 2
+                ;;
+            --isolation)
+                [[ $# -ge 2 ]] || abort "Usage: clod set --isolation <on|off>"
+                isolation_value="$2"
                 shift 2
                 ;;
             --dir)
@@ -627,7 +633,29 @@ vm_set() {
         fi
     fi
 
-    if [[ -z "$ram_value" ]] && [[ -z "$max_memory_value" ]] && [[ -z "$vm_count_value" ]] && [[ -z "$dir_value" ]] && [[ -z "$dir_remove_value" ]]; then
+    if [[ -n "$isolation_value" ]]; then
+        case "$isolation_value" in
+            on)
+                set_setting "isolate_projects" "true"
+                info "Project isolation enabled — the default 'xcode' VM mounts only the active project"
+                ;;
+            off)
+                sqlite3 "$DB_FILE" "DELETE FROM settings WHERE key = 'isolate_projects';"
+                info "Project isolation disabled — the default 'xcode' VM mounts all projects"
+                ;;
+            *)
+                abort "Invalid --isolation value '$isolation_value'. Use on or off."
+                ;;
+        esac
+
+        local vm_name
+        vm_name="$(vm_get_instance_vm_name "xcode")"
+        if [[ -n "$vm_name" ]] && [[ "$(get_vm_state "$vm_name")" == "running" ]]; then
+            warn "xcode is running — change takes effect on next launch"
+        fi
+    fi
+
+    if [[ -z "$ram_value" ]] && [[ -z "$max_memory_value" ]] && [[ -z "$vm_count_value" ]] && [[ -z "$isolation_value" ]] && [[ -z "$dir_value" ]] && [[ -z "$dir_remove_value" ]]; then
         abort "Usage: clod set [options] [NAME]. Run 'clod help set' for details."
     fi
 }
@@ -689,8 +717,8 @@ EOF
         abort "Failed to record xcode instance"
     fi
 
-    # Mark all projects as active after build
-    sqlite3 "$DB_FILE" "UPDATE projects SET active = 1;"
+    # Mark mounted projects as active after build
+    mark_projects_active
 
     info "Built xcode instance"
 }

--- a/lib/project.sh
+++ b/lib/project.sh
@@ -3,14 +3,39 @@
 # Project management: add, remove, list, select, directory mapping
 
 check_projects_active() {
-    # Returns 0 (success) if all projects are active, 1 otherwise
-    local inactive_count
-    inactive_count=$(sqlite3 "$DB_FILE" <<EOF
+    # Returns 0 (success) if the projects marked active match what the VM
+    # should mount, 1 otherwise. With isolation enabled only the primary
+    # (most recent) project should be active; otherwise all of them.
+    local stale_count
+    if [[ "$(get_setting "isolate_projects" "false")" == "true" ]]; then
+        stale_count=$(sqlite3 "$DB_FILE" <<EOF
+SELECT COUNT(*) FROM projects
+WHERE active != (CASE WHEN rowid = (SELECT rowid FROM projects ORDER BY date_added DESC LIMIT 1)
+                      THEN 1 ELSE 0 END);
+EOF
+)
+    else
+        stale_count=$(sqlite3 "$DB_FILE" <<EOF
 SELECT COUNT(*) FROM projects WHERE active = 0;
 EOF
 )
-    trace "Inactive projects: $inactive_count"
-    [[ "$inactive_count" -eq 0 ]]
+    fi
+    trace "Stale project mounts: $stale_count"
+    [[ "$stale_count" -eq 0 ]]
+}
+
+# Mark projects as mounted after the xcode VM starts: all of them, or only
+# the primary project when isolation is enabled.
+mark_projects_active() {
+    if [[ "$(get_setting "isolate_projects" "false")" == "true" ]]; then
+        sqlite3 "$DB_FILE" <<EOF
+UPDATE projects SET active = (rowid = (SELECT rowid FROM projects ORDER BY date_added DESC LIMIT 1));
+EOF
+    else
+        sqlite3 "$DB_FILE" <<EOF
+UPDATE projects SET active = 1;
+EOF
+    fi
 }
 
 add_project () {
@@ -304,8 +329,12 @@ EOF
 # Outputs NUL-delimited entries like: "--dir" NUL "name:path" NUL
 get_map_directories() {
     local result
+    local limit=""
+    if [[ "$(get_setting "isolate_projects" "false")" == "true" ]]; then
+        limit=" LIMIT 1"
+    fi
     result=$(sqlite3 -separator '|' "$DB_FILE" <<EOF || return 1
-SELECT name, path FROM projects ORDER BY date_added DESC;
+SELECT name, path FROM projects ORDER BY date_added DESC${limit};
 EOF
 )
 

--- a/lib/vm.sh
+++ b/lib/vm.sh
@@ -334,10 +334,8 @@ run_vm () {
         return "$status"
     fi
 
-    # Mark all projects as active after virtual machine starts successfully
-    sqlite3 "$DB_FILE" <<EOF
-UPDATE projects SET active = 1;
-EOF
+    # Mark mounted projects as active after virtual machine starts successfully
+    mark_projects_active
 }
 
 stop_vm () {

--- a/spec/isolation_spec.sh
+++ b/spec/isolation_spec.sh
@@ -1,0 +1,121 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154 # TEST_TMPDIR set by spec_helper.sh
+
+Describe 'project isolation'
+    Include lib/common.sh
+    Include lib/db.sh
+    Include lib/vm.sh
+    Include lib/project.sh
+    Include lib/instance.sh
+
+    setup_db() {
+        DB_FILE="$TEST_TMPDIR/test.sqlite"
+        init_db
+        mkdir -p "$TEST_TMPDIR/alpha" "$TEST_TMPDIR/beta"
+        sqlite3 "$DB_FILE" "INSERT INTO projects (path, name, date_added) VALUES ('$TEST_TMPDIR/alpha', 'alpha', '2026-01-01 00:00:00');"
+        sqlite3 "$DB_FILE" "INSERT INTO projects (path, name, date_added) VALUES ('$TEST_TMPDIR/beta', 'beta', '2026-01-02 00:00:00');"
+    }
+    BeforeEach 'setup_db'
+
+    get_vm_state() { echo "stopped"; }
+    count_active() { sqlite3 "$DB_FILE" "SELECT COUNT(*) FROM projects WHERE active = 1;"; }
+    active_names() { sqlite3 "$DB_FILE" "SELECT name FROM projects WHERE active = 1;"; }
+    isolation_setting() { sqlite3 "$DB_FILE" "SELECT value FROM settings WHERE key = 'isolate_projects';"; }
+    map_dirs() { get_map_directories | tr '\0' '\n'; }
+
+    Describe 'vm_get_instance_dirs xcode'
+        It 'returns all projects when isolation is off'
+            When call vm_get_instance_dirs "xcode"
+            The line 1 of output should eq "beta|$TEST_TMPDIR/beta|1"
+            The line 2 of output should eq "alpha|$TEST_TMPDIR/alpha|0"
+        End
+
+        It 'returns only the primary project when isolation is on'
+            set_setting "isolate_projects" "true"
+            When call vm_get_instance_dirs "xcode"
+            The output should eq "beta|$TEST_TMPDIR/beta|1"
+        End
+    End
+
+    Describe 'get_map_directories'
+        It 'maps all projects when isolation is off'
+            When call map_dirs
+            The output should include "alpha:$TEST_TMPDIR/alpha"
+            The output should include "beta:$TEST_TMPDIR/beta"
+        End
+
+        It 'maps only the primary project when isolation is on'
+            set_setting "isolate_projects" "true"
+            When call map_dirs
+            The output should include "beta:$TEST_TMPDIR/beta"
+            The output should not include "alpha:$TEST_TMPDIR/alpha"
+        End
+    End
+
+    Describe 'mark_projects_active'
+        It 'marks all projects active when isolation is off'
+            When call mark_projects_active
+            The result of function count_active should eq "2"
+        End
+
+        It 'marks only the primary project active when isolation is on'
+            set_setting "isolate_projects" "true"
+            When call mark_projects_active
+            The result of function count_active should eq "1"
+            The result of function active_names should eq "beta"
+        End
+    End
+
+    Describe 'check_projects_active'
+        It 'fails when a project is inactive and isolation is off'
+            sqlite3 "$DB_FILE" "UPDATE projects SET active = 1 WHERE name = 'beta';"
+            When call check_projects_active
+            The status should be failure
+        End
+
+        It 'succeeds when only the primary is active and isolation is on'
+            set_setting "isolate_projects" "true"
+            sqlite3 "$DB_FILE" "UPDATE projects SET active = 1 WHERE name = 'beta';"
+            When call check_projects_active
+            The status should be success
+        End
+
+        It 'fails when a non-primary project is still active and isolation is on'
+            set_setting "isolate_projects" "true"
+            sqlite3 "$DB_FILE" "UPDATE projects SET active = 1;"
+            When call check_projects_active
+            The status should be failure
+        End
+
+        It 'fails when the primary project changed and isolation is on'
+            set_setting "isolate_projects" "true"
+            sqlite3 "$DB_FILE" "UPDATE projects SET active = 1 WHERE name = 'beta';"
+            sqlite3 "$DB_FILE" "UPDATE projects SET date_added = '2026-01-03 00:00:00' WHERE name = 'alpha';"
+            When call check_projects_active
+            The status should be failure
+        End
+    End
+
+    Describe 'clod set --isolation'
+        It 'enables isolation with on'
+            When call vm_set --isolation on
+            The status should be success
+            The stderr should include "isolation enabled"
+            The result of function isolation_setting should eq "true"
+        End
+
+        It 'disables isolation with off'
+            set_setting "isolate_projects" "true"
+            When call vm_set --isolation off
+            The status should be success
+            The stderr should include "isolation disabled"
+            The result of function isolation_setting should eq ""
+        End
+
+        It 'rejects invalid values'
+            When run vm_set --isolation sideways
+            The status should be failure
+            The stderr should include "Invalid --isolation value"
+        End
+    End
+End


### PR DESCRIPTION
Hi, I had always needed to make agents have access to minimum files in projects therefore I found clodpod initially. After some usage I had many projects and eventually created project selector as contribution to this repo. And now having the need to isolate projects some time to make agent laser focus without getting info from going to project's parent folder and read files of other clodpod projects from there, I created optional isolation mode. Below is a agent summary of the PR. I am using it for almost 2 days and have no problems with it so far. As always I am fully open to discussion and comments and critiques are welcomed. 

## Optional project isolation

Adds a persistent `isolate_projects` setting, toggled with:

    clod set --isolation on   # mount only the active project in the default 'xcode' VM
    clod set --isolation off  # restore mounting all projects

By default the shared `xcode` VM mounts every registered project, so agents can
see all of them. With isolation enabled it mounts **only the primary (most
recently added/selected) project** — other projects stay registered but are not
visible inside the VM. For full isolation including VM state, named instances
remain the recommended path (README now cross-references this).

## Changes

- **`lib/db.sh` / `lib/project.sh`**: `vm_get_instance_dirs` and
  `get_map_directories` restrict to the primary project when isolation is on,
  so VM launch and directory mapping share one source of truth.
- **`lib/project.sh`**: new `mark_projects_active` helper replaces the four
  scattered `UPDATE projects SET active = 1` calls; the `active` column now
  means "mounted projects match what should be mounted."
  `check_projects_active` detects staleness in both directions, including a
  changed primary project under isolation — which correctly triggers the
  restart prompt on next connect.
- **`lib/instance.sh`**: `clod set --isolation on|off` with validation; `off`
  deletes the setting row instead of storing `false`. Toggling while the xcode
  VM runs warns that the change applies on next launch; the VM name is resolved
  via `vm_get_instance_vm_name`, so a renamed or missing xcode instance is
  handled like the other `clod set` options.
- **`README.md` / help text**: new "Project isolation" section and `clod set`
  docs.

## Upgrade behavior

No migration and no behavior change for existing installs: the setting row
doesn't exist until `--isolation on` is run, every read site defaults to off
via `get_setting "isolate_projects" "false"`, and existing DBs (all projects
`active = 1`) pass `check_projects_active` unchanged — so no spurious restart
prompt after updating.

## Tests

New `spec/isolation_spec.sh` covering both isolation states for instance dir
resolution, directory mapping, active-marking, and staleness detection
(including the primary-changed case), plus `--isolation` flag validation.
Full shellspec suite passes (78 examples, 0 failures).