### PR TITLE
Declare base image dependencies in a Brewfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Optional virtual machine configuration (example):
 
 To add custom configuration; see `./guest/home/README.md`.
 
+### Base image dependencies (guest/Brewfile)
+
+Everything the base image ships — command-line tools and AI agent casks — is declared in [`guest/Brewfile`](guest/Brewfile), applied by `guest/install.sh` during `clod build-base`. To add a tool for every VM, add a line there and rebuild:
+
+    clod --rebuild-base
+
+Prefer a per-project Brewfile (below) when the dependency belongs to one project: those reconcile on every shell entry and need no rebuild.
+
 ### Per-project Homebrew dependencies (Brewfile)
 
 If a mounted project contains a [Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile) at its root, ClodPod will reconcile it via `brew bundle` automatically:

--- a/guest/Brewfile
+++ b/guest/Brewfile
@@ -1,0 +1,32 @@
+# ClodPod base image dependencies.
+#
+# Applied by guest/install.sh during 'clod build-base'. This is layer 1 (the
+# base image), so changes here need a 'clod --rebuild-base' to take effect.
+#
+# Project-level dependencies belong in a project's own ./Brewfile instead —
+# those reconcile on every shell entry with no rebuild. See guest/home/README.md.
+
+# Command-line tools
+brew "bash"             # replace OSX bash 3.2 with something modern
+brew "bat"              # better cat
+brew "coreutils"        # replace old BSD command-line tools with GNU
+brew "eza"              # better ls
+brew "fd"               # better than unix `find`
+brew "findutils"        # includes gxargs with the '-r' option
+brew "git"              # yeah, it's the best
+brew "git-delta"        # better pager for git diff
+brew "git-lfs"          # big files
+brew "gnu-getopt"       # because OSX getopt is ancient
+brew "jq"               # mangle JSON from the command line
+brew "mas"              # Apple Store command line
+brew "node"             # NodeJS
+brew "python"           # Python language
+brew "rg"               # better grep (alias for ripgrep)
+brew "sd"               # better sed
+brew "shellcheck"       # lint for bash
+brew "uv"               # python package manager
+brew "wget"             # curl with different defaults
+
+# AI developer tools
+cask "claude-code"      # Anthropic Claude Code
+cask "codex"            # OpenAI Codex

--- a/guest/install.sh
+++ b/guest/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
-#SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ALLOW_SUDO="${ALLOW_SUDO:-false}"
 
@@ -62,54 +62,28 @@ else
     brew update && brew upgrade
 fi
 
-BrewApps=()
-BrewApps+=(bash)                # replace OSX bash 3.2 with something modern
-BrewApps+=(bat)                 # better cat
-BrewApps+=(coreutils)           # replace old BSD command-line tools with GNU
-BrewApps+=(eza)                 # better ls
-BrewApps+=(fd)                  # better than unix `find`
-BrewApps+=(findutils)           # includes gxargs with the '-r' option
-BrewApps+=(git)                 # yeah, it's the best
-BrewApps+=(git-delta)           # better pager for git diff
-BrewApps+=(git-lfs)             # big files
-BrewApps+=(gnu-getopt)          # because OSX getopt is ancient
-BrewApps+=(jq)                  # mangle JSON from the command line
-BrewApps+=(mas)                 # Apple Store command line
-BrewApps+=(node)                # NodeJS
-BrewApps+=(python)              # Python language
-BrewApps+=(rg)                  # better grep
-BrewApps+=(sd)                  # better sed
-BrewApps+=(shellcheck)          # lint for bash
-BrewApps+=(uv)                  # python package manager
-BrewApps+=(wget)                # curl with different defaults
+###############################################################################
+# Install base dependencies from the Brewfile
+#
+# guest/Brewfile is the single source of truth for what the base image ships —
+# formulae and AI agent casks alike. 'brew bundle' is idempotent: it reconciles
+# against installed state rather than failing on already-installed packages,
+# which is why this needs none of the '|| true' guards it replaces.
+###############################################################################
+BREWFILE="$SCRIPT_DIR/Brewfile"
+[[ -f "$BREWFILE" ]] || abort "Brewfile not found at $BREWFILE"
 
-debug "Installing ${BrewApps[*]}..."
+debug "Installing base dependencies from Brewfile..."
 if [[ "$VERBOSE" -lt 3 ]]; then
-    brew install --quiet "${BrewApps[@]}"
+    brew bundle install --quiet --file="$BREWFILE"
 else
-    brew install "${BrewApps[@]}"
+    brew bundle install --file="$BREWFILE"
 fi
 
 
 ###############################################################################
-# Install AI developer tools
+# Install AI developer tools not available via Homebrew
 ###############################################################################
-debug "Installing AI developer tools..."
-
-# Claude Code (brew cask)
-if [[ "$VERBOSE" -lt 3 ]]; then
-    brew install --quiet --cask claude-code 2>/dev/null || brew upgrade --quiet --cask claude-code 2>/dev/null || true
-else
-    brew install --cask claude-code 2>/dev/null || brew upgrade --cask claude-code 2>/dev/null || true
-fi
-
-# Codex (brew cask)
-if [[ "$VERBOSE" -lt 3 ]]; then
-    brew install --quiet --cask codex 2>/dev/null || brew upgrade --quiet --cask codex 2>/dev/null || true
-else
-    brew install --cask codex 2>/dev/null || brew upgrade --cask codex 2>/dev/null || true
-fi
-
 # Gemini CLI (npm global)
 if command -v npm &>/dev/null; then
     debug "Installing gemini-cli via npm..."

--- a/spec/guest_brewfile_spec.sh
+++ b/spec/guest_brewfile_spec.sh
@@ -1,0 +1,104 @@
+# shellcheck shell=bash
+#
+# Guards the base-image Brewfile against regression.
+#
+# guest/Brewfile replaces the hand-rolled BrewApps array that used to live in
+# guest/install.sh. Because the base image is expensive to rebuild, a package
+# silently dropped from this file would not surface until someone rebuilt and
+# found a missing tool. These examples pin the full inventory instead.
+
+Describe 'guest/Brewfile'
+    BREWFILE="${SHELLSPEC_PROJECT_ROOT}/guest/Brewfile"
+
+    # Match a 'brew "name"' or 'cask "name"' entry, tolerating trailing
+    # options (e.g. ', start_service: true') and any leading indentation.
+    declares() {
+        local kind="$1" name="$2"
+        grep -Eq "^[[:space:]]*${kind}[[:space:]]+\"${name}\"([[:space:],]|\$)" "$BREWFILE"
+    }
+
+    # Every meaningful line must be a Brewfile DSL entry. Catches a stray
+    # shell-ism left behind by the port from install.sh.
+    non_dsl_lines() {
+        grep -vE '^[[:space:]]*(#|$)' "$BREWFILE" \
+            | grep -vE '^[[:space:]]*(brew|cask|tap|mas|vscode|whalebrew)[[:space:]]+"' \
+            || true
+    }
+
+    It 'exists'
+        The path "$BREWFILE" should be exist
+    End
+
+    Describe 'command-line tools'
+        Parameters
+            bash            # replaces the ancient OSX bash 3.2
+            bat             # better cat
+            coreutils       # GNU replacements for BSD tools
+            eza             # better ls
+            fd              # better find
+            findutils       # gxargs with '-r'
+            git
+            git-delta       # pager for git diff
+            git-lfs
+            gnu-getopt      # OSX getopt is ancient
+            jq
+            mas             # Apple Store CLI
+            node
+            python
+            rg              # alias for ripgrep; brew bundle resolves aliases
+            sd              # better sed
+            shellcheck
+            uv
+            wget
+        End
+
+        It "declares $1"
+            When call declares brew "$1"
+            The status should be success
+        End
+    End
+
+    Describe 'AI agent casks'
+        Parameters
+            claude-code
+            codex
+        End
+
+        It "declares $1"
+            When call declares cask "$1"
+            The status should be success
+        End
+    End
+
+    It 'contains only Brewfile DSL entries'
+        When call non_dsl_lines
+        The output should equal ""
+    End
+End
+
+Describe 'guest/install.sh'
+    INSTALL_SH="${SHELLSPEC_PROJECT_ROOT}/guest/install.sh"
+
+    # The Brewfile must be the single source of truth for base packages.
+    # A second inventory inside install.sh is how the two drift apart.
+    ad_hoc_brew_installs() {
+        grep -nE '^[[:space:]]*brew (install|upgrade)' "$INSTALL_SH" \
+            | grep -vE 'brew (install|upgrade) *$' \
+            || true
+    }
+
+    It 'installs base packages via brew bundle'
+        When call grep -qE 'brew bundle install .*--file=' "$INSTALL_SH"
+        The status should be success
+    End
+
+    It 'no longer carries its own package inventory'
+        When call grep -q 'BrewApps' "$INSTALL_SH"
+        The status should be failure
+    End
+
+    It 'has no ad-hoc brew install lines outside the Brewfile'
+        When call ad_hoc_brew_installs
+        The output should equal ""
+    End
+End


### PR DESCRIPTION
A little refactor to migrate the current brew installation -> Homebrew Brewfile.

install.sh carried its own package inventory as a bash array plus bespoke '|| true' cask handling, so adding a tool meant editing imperative shell in two styles. Move both to guest/Brewfile and let 'brew bundle' reconcile — it is idempotent against installed state, which is what the '|| true' guards were working around.

Specs pin the full inventory and fail if packages drift back into install.sh, since a dropped package only surfaces on a slow base rebuild.