### PR TITLE
herdr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ClodPod virtual machines include Xcode and common development tools, and it's ea
 - Builds a virtual machine and launches AI agents with access to your projects
 - Enables mapping multiple projects in the same virtual machine simultaneously
 - Open multiple AI agents sessions and shell prompts, or use the GUI
+- Bundled `herdr` agent multiplexer for running many agents in a single session
 - Headless mode for CI/CD workflows with `--no-graphics`
 - Includes Xcode and common development tools; you can add your own tools too
 - Fast rebuild and relaunch using a three-layer APFS CoW caching system
@@ -54,6 +55,10 @@ Usage:
     clod gemini
     # also "clod g"
 
+    # Run herdr, the agent multiplexer (many agents in one VM)
+    clod herdr
+    # also "clod hd"
+
     # Or a command shell
     clod shell
     # also "clod s"
@@ -75,6 +80,33 @@ Usage:
     clod remove "FOURTH PROJECT DIRECTORY"      # also "clod rm ..."
     clod list                                   # also "clod l", "clod ls"
 
+
+## Running multiple agents with herdr
+
+Running several agents concurrently normally means several terminal windows,
+each with its own `clod claude`. [herdr](https://herdr.dev) is an agent-aware
+terminal multiplexer — tmux for coding agents — that collapses this into one
+session:
+
+    clod herdr
+
+From inside, split panes and launch `claude`, `codex`, or `gemini` in each.
+herdr's sidebar reports what every agent is doing (working, blocked, done,
+idle), so a blocked agent waiting on a prompt is visible instead of buried in
+a background window.
+
+Sessions persist in the VM. Detach with `prefix+q` and your agents keep
+running; `clod herdr` reattaches.
+
+Arguments after `--` pass through to herdr, so a second, independent session
+is just:
+
+    clod herdr . -- --session experiments
+
+herdr is installed in the base image, and its server runs as a background
+service. Integrations for Claude Code, Codex, and Cursor Agent are installed
+at instance creation so agent-state detection is authoritative rather than
+heuristic.
 
 ## Named VM instances
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Optional virtual machine configuration (example):
 
 To add custom configuration; see `./guest/home/README.md`.
 
+### Base image dependencies (guest/Brewfile)
+
+Everything the base image ships — command-line tools and AI agent casks — is declared in [`guest/Brewfile`](guest/Brewfile), applied by `guest/install.sh` during `clod build-base`. To add a tool for every VM, add a line there and rebuild:
+
+    clod --rebuild-base
+
+Prefer a per-project Brewfile (below) when the dependency belongs to one project: those reconcile on every shell entry and need no rebuild.
+
 ### Per-project Homebrew dependencies (Brewfile)
 
 If a mounted project contains a [Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile) at its root, ClodPod will reconcile it via `brew bundle` automatically:

--- a/clod
+++ b/clod
@@ -329,6 +329,11 @@ case "${1:-}" in
         PROJECT_DIR="${2:-}"
         PROJECT_NAME="${3:-}"
         ;;
+    herdr|hd)
+        COMMAND=herdr
+        PROJECT_DIR="${2:-}"
+        PROJECT_NAME="${3:-}"
+        ;;
     shell|sh|s)
         unset COMMAND
         IS_SHELL_COMMAND=true

--- a/guest/Brewfile
+++ b/guest/Brewfile
@@ -1,0 +1,32 @@
+# ClodPod base image dependencies.
+#
+# Applied by guest/install.sh during 'clod build-base'. This is layer 1 (the
+# base image), so changes here need a 'clod --rebuild-base' to take effect.
+#
+# Project-level dependencies belong in a project's own ./Brewfile instead —
+# those reconcile on every shell entry with no rebuild. See guest/home/README.md.
+
+# Command-line tools
+brew "bash"             # replace OSX bash 3.2 with something modern
+brew "bat"              # better cat
+brew "coreutils"        # replace old BSD command-line tools with GNU
+brew "eza"              # better ls
+brew "fd"               # better than unix `find`
+brew "findutils"        # includes gxargs with the '-r' option
+brew "git"              # yeah, it's the best
+brew "git-delta"        # better pager for git diff
+brew "git-lfs"          # big files
+brew "gnu-getopt"       # because OSX getopt is ancient
+brew "jq"               # mangle JSON from the command line
+brew "mas"              # Apple Store command line
+brew "node"             # NodeJS
+brew "python"           # Python language
+brew "rg"               # better grep (alias for ripgrep)
+brew "sd"               # better sed
+brew "shellcheck"       # lint for bash
+brew "uv"               # python package manager
+brew "wget"             # curl with different defaults
+
+# AI developer tools
+cask "claude-code"      # Anthropic Claude Code
+cask "codex"            # OpenAI Codex

--- a/guest/Brewfile
+++ b/guest/Brewfile
@@ -30,3 +30,7 @@ brew "wget"             # curl with different defaults
 # AI developer tools
 cask "claude-code"      # Anthropic Claude Code
 cask "codex"            # OpenAI Codex
+
+# Agent multiplexer. start_service runs 'herdr server', which owns the panes
+# and outlives any single shell — that persistence is the whole point.
+brew "herdr", start_service: true

--- a/guest/configure.sh
+++ b/guest/configure.sh
@@ -85,6 +85,26 @@ sudo chown -R "admin:staff" "$(brew --prefix)"
 
 
 ###############################################################################
+# Install herdr agent integrations
+#
+# Without an installed integration herdr detects agent state heuristically,
+# and the working/blocked/done sidebar — the reason to use it over tmux —
+# becomes guesswork. Only agents ClodPod preinstalls are wired here; gemini
+# has no herdr integration and falls back to heuristic detection.
+#
+# Failures warn but never abort: a missing integration costs sidebar accuracy,
+# not the instance.
+###############################################################################
+if command -v herdr >/dev/null 2>&1; then
+    debug "Installing herdr agent integrations..."
+    for integration in claude codex cursor; do
+        herdr integration install "$integration" >/dev/null 2>&1 \
+            || warn "herdr integration install $integration failed — continuing"
+    done
+fi
+
+
+###############################################################################
 # Apply project Brewfiles
 # Project mounts surface under /Volumes/My Shared Files/<name>. Each project
 # may ship a ./Brewfile; we reconcile it via 'brew bundle'. Failures warn

--- a/guest/home/bin/herdr
+++ b/guest/home/bin/herdr
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Resolve the real binary by path, never via 'command -v': .zshrc puts
+# $HOME/bin ahead of Homebrew, so a PATH lookup finds this shim and recurses.
+APP=""
+for candidate in \
+    "${HOMEBREW_PREFIX:-/opt/homebrew}/bin/herdr" \
+    "$HOME/.local/bin/herdr" \
+; do
+    if [[ -x "$candidate" ]]; then
+        APP="$candidate"
+        break
+    fi
+done
+
+# The Brewfile installs herdr into the base image; this covers a VM built
+# before it was added, matching how the agent shims self-heal.
+if [[ -z "$APP" ]]; then
+    echo >&2 "Installing herdr..."
+    curl -fsSL https://herdr.dev/install.sh | sh
+    APP="$HOME/.local/bin/herdr"
+fi
+
+# No flags injected: herdr is a multiplexer, not an agent. Bare invocation
+# attaches the default session, and 'clod herdr -- --session NAME' or any
+# other subcommand passes straight through.
+exec "$APP" "$@"

--- a/guest/install.sh
+++ b/guest/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
-#SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ALLOW_SUDO="${ALLOW_SUDO:-false}"
 
@@ -62,54 +62,28 @@ else
     brew update && brew upgrade
 fi
 
-BrewApps=()
-BrewApps+=(bash)                # replace OSX bash 3.2 with something modern
-BrewApps+=(bat)                 # better cat
-BrewApps+=(coreutils)           # replace old BSD command-line tools with GNU
-BrewApps+=(eza)                 # better ls
-BrewApps+=(fd)                  # better than unix `find`
-BrewApps+=(findutils)           # includes gxargs with the '-r' option
-BrewApps+=(git)                 # yeah, it's the best
-BrewApps+=(git-delta)           # better pager for git diff
-BrewApps+=(git-lfs)             # big files
-BrewApps+=(gnu-getopt)          # because OSX getopt is ancient
-BrewApps+=(jq)                  # mangle JSON from the command line
-BrewApps+=(mas)                 # Apple Store command line
-BrewApps+=(node)                # NodeJS
-BrewApps+=(python)              # Python language
-BrewApps+=(rg)                  # better grep
-BrewApps+=(sd)                  # better sed
-BrewApps+=(shellcheck)          # lint for bash
-BrewApps+=(uv)                  # python package manager
-BrewApps+=(wget)                # curl with different defaults
+###############################################################################
+# Install base dependencies from the Brewfile
+#
+# guest/Brewfile is the single source of truth for what the base image ships —
+# formulae and AI agent casks alike. 'brew bundle' is idempotent: it reconciles
+# against installed state rather than failing on already-installed packages,
+# which is why this needs none of the '|| true' guards it replaces.
+###############################################################################
+BREWFILE="$SCRIPT_DIR/Brewfile"
+[[ -f "$BREWFILE" ]] || abort "Brewfile not found at $BREWFILE"
 
-debug "Installing ${BrewApps[*]}..."
+debug "Installing base dependencies from Brewfile..."
 if [[ "$VERBOSE" -lt 3 ]]; then
-    brew install --quiet "${BrewApps[@]}"
+    brew bundle install --quiet --file="$BREWFILE"
 else
-    brew install "${BrewApps[@]}"
+    brew bundle install --file="$BREWFILE"
 fi
 
 
 ###############################################################################
-# Install AI developer tools
+# Install AI developer tools not available via Homebrew
 ###############################################################################
-debug "Installing AI developer tools..."
-
-# Claude Code (brew cask)
-if [[ "$VERBOSE" -lt 3 ]]; then
-    brew install --quiet --cask claude-code 2>/dev/null || brew upgrade --quiet --cask claude-code 2>/dev/null || true
-else
-    brew install --cask claude-code 2>/dev/null || brew upgrade --cask claude-code 2>/dev/null || true
-fi
-
-# Codex (brew cask)
-if [[ "$VERBOSE" -lt 3 ]]; then
-    brew install --quiet --cask codex 2>/dev/null || brew upgrade --quiet --cask codex 2>/dev/null || true
-else
-    brew install --cask codex 2>/dev/null || brew upgrade --cask codex 2>/dev/null || true
-fi
-
 # Gemini CLI (npm global)
 if command -v npm &>/dev/null; then
     debug "Installing gemini-cli via npm..."

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -57,6 +57,7 @@ Commands:
   codex, co         Run OpenAI Codex in VM
   cursor, cu, ca    Run Cursor Agent in VM
   gemini, gem, g    Run Google Gemini in VM
+  herdr, hd         Run herdr agent multiplexer in VM
   shell, sh, s      Open shell in VM
   create, cr        Create a named VM instance
   destroy           Delete a named VM instance
@@ -312,6 +313,7 @@ dispatch_help() {
         codex|co)           show_help_command "codex [PATH] [NAME] [-- args...]" "Run OpenAI Codex in a VM." ;;
         cursor|cu|ca)       show_help_command "cursor [PATH] [NAME] [-- args...]" "Run Cursor Agent in a VM." ;;
         gemini|gem|g)       show_help_command "gemini [PATH] [NAME] [-- args...]" "Run Google Gemini in a VM." ;;
+        herdr|hd)           show_help_command "herdr [PATH] [NAME] [-- args...]" "Run the herdr agent multiplexer in a VM, hosting many agents in panes. Args pass through, e.g. '-- --session work'." ;;
         start)              show_help_start ;;
         add|a)              show_help_command "add PATH [NAME]" "Add a project directory. NAME defaults to directory basename." ;;
         remove|rm)          show_help_command "remove <name|path>" "Remove a project by name or path." ;;

--- a/spec/guest_brewfile_spec.sh
+++ b/spec/guest_brewfile_spec.sh
@@ -1,0 +1,104 @@
+# shellcheck shell=bash
+#
+# Guards the base-image Brewfile against regression.
+#
+# guest/Brewfile replaces the hand-rolled BrewApps array that used to live in
+# guest/install.sh. Because the base image is expensive to rebuild, a package
+# silently dropped from this file would not surface until someone rebuilt and
+# found a missing tool. These examples pin the full inventory instead.
+
+Describe 'guest/Brewfile'
+    BREWFILE="${SHELLSPEC_PROJECT_ROOT}/guest/Brewfile"
+
+    # Match a 'brew "name"' or 'cask "name"' entry, tolerating trailing
+    # options (e.g. ', start_service: true') and any leading indentation.
+    declares() {
+        local kind="$1" name="$2"
+        grep -Eq "^[[:space:]]*${kind}[[:space:]]+\"${name}\"([[:space:],]|\$)" "$BREWFILE"
+    }
+
+    # Every meaningful line must be a Brewfile DSL entry. Catches a stray
+    # shell-ism left behind by the port from install.sh.
+    non_dsl_lines() {
+        grep -vE '^[[:space:]]*(#|$)' "$BREWFILE" \
+            | grep -vE '^[[:space:]]*(brew|cask|tap|mas|vscode|whalebrew)[[:space:]]+"' \
+            || true
+    }
+
+    It 'exists'
+        The path "$BREWFILE" should be exist
+    End
+
+    Describe 'command-line tools'
+        Parameters
+            bash            # replaces the ancient OSX bash 3.2
+            bat             # better cat
+            coreutils       # GNU replacements for BSD tools
+            eza             # better ls
+            fd              # better find
+            findutils       # gxargs with '-r'
+            git
+            git-delta       # pager for git diff
+            git-lfs
+            gnu-getopt      # OSX getopt is ancient
+            jq
+            mas             # Apple Store CLI
+            node
+            python
+            rg              # alias for ripgrep; brew bundle resolves aliases
+            sd              # better sed
+            shellcheck
+            uv
+            wget
+        End
+
+        It "declares $1"
+            When call declares brew "$1"
+            The status should be success
+        End
+    End
+
+    Describe 'AI agent casks'
+        Parameters
+            claude-code
+            codex
+        End
+
+        It "declares $1"
+            When call declares cask "$1"
+            The status should be success
+        End
+    End
+
+    It 'contains only Brewfile DSL entries'
+        When call non_dsl_lines
+        The output should equal ""
+    End
+End
+
+Describe 'guest/install.sh'
+    INSTALL_SH="${SHELLSPEC_PROJECT_ROOT}/guest/install.sh"
+
+    # The Brewfile must be the single source of truth for base packages.
+    # A second inventory inside install.sh is how the two drift apart.
+    ad_hoc_brew_installs() {
+        grep -nE '^[[:space:]]*brew (install|upgrade)' "$INSTALL_SH" \
+            | grep -vE 'brew (install|upgrade) *$' \
+            || true
+    }
+
+    It 'installs base packages via brew bundle'
+        When call grep -qE 'brew bundle install .*--file=' "$INSTALL_SH"
+        The status should be success
+    End
+
+    It 'no longer carries its own package inventory'
+        When call grep -q 'BrewApps' "$INSTALL_SH"
+        The status should be failure
+    End
+
+    It 'has no ad-hoc brew install lines outside the Brewfile'
+        When call ad_hoc_brew_installs
+        The output should equal ""
+    End
+End

--- a/spec/help_spec.sh
+++ b/spec/help_spec.sh
@@ -26,6 +26,7 @@ Describe 'top-level help'
         The output should include "clone-base"
         The output should include "shell, sh, s"
         The output should include "help, h"
+        The output should include "herdr, hd"
     End
 
     It 'shows VM layers'
@@ -120,6 +121,16 @@ Describe 'dispatch_help'
     It 'dispatches simple commands'
         When call dispatch_help "claude"
         The output should include "Claude Code"
+    End
+
+    It 'dispatches herdr'
+        When call dispatch_help "herdr"
+        The output should include "herdr"
+    End
+
+    It 'dispatches hd alias'
+        When call dispatch_help "hd"
+        The output should include "herdr"
     End
 
     It 'dispatches cl alias'

--- a/spec/herdr_spec.sh
+++ b/spec/herdr_spec.sh
@@ -1,0 +1,77 @@
+# shellcheck shell=bash
+#
+# herdr is the agent multiplexer: one VM session hosting many agents in panes,
+# rather than one terminal window per 'clod claude'. These examples pin the
+# three places that wiring lives — the Brewfile entry, the launcher shim, and
+# the clod dispatch arm — since none of them is exercised without a VM.
+
+Describe 'herdr integration'
+
+    Describe 'guest/Brewfile'
+        BREWFILE="${SHELLSPEC_PROJECT_ROOT}/guest/Brewfile"
+
+        It 'declares herdr'
+            When call grep -qE '^[[:space:]]*brew "herdr"' "$BREWFILE"
+            The status should be success
+        End
+
+        # herdr runs a background server that owns the panes. Without
+        # start_service the daemon dies with the shell that spawned it.
+        It 'starts the herdr server as a service'
+            When call grep -qE '^[[:space:]]*brew "herdr".*start_service:[[:space:]]*true' "$BREWFILE"
+            The status should be success
+        End
+    End
+
+    Describe 'guest/home/bin/herdr shim'
+        SHIM="${SHELLSPEC_PROJECT_ROOT}/guest/home/bin/herdr"
+
+        It 'exists'
+            The path "$SHIM" should be exist
+        End
+
+        It 'is executable'
+            The path "$SHIM" should be executable
+        End
+
+        # Pass-through is what makes 'clod herdr . -- --session other' work:
+        # .zshrc execs COMMAND with COMMAND_ARGS appended.
+        # Pass-through with nothing spliced in between. The agent shims force
+        # an auto-approve flag; herdr is a multiplexer, not an agent, and an
+        # injected flag would shadow its subcommands.
+        It 'execs the real binary with arguments verbatim'
+            When call grep -qF 'exec "$APP" "$@"' "$SHIM"
+            The status should be success
+        End
+
+        It 'injects no auto-approve flag'
+            When call grep -qE 'dangerously|--yolo' "$SHIM"
+            The status should be failure
+        End
+    End
+
+    Describe 'clod dispatch'
+        CLOD="${SHELLSPEC_PROJECT_ROOT}/clod"
+
+        It 'accepts the herdr command and hd alias'
+            When call grep -qE '^[[:space:]]*herdr\|hd\)' "$CLOD"
+            The status should be success
+        End
+
+        It 'runs herdr as the guest command'
+            When call grep -qE '^[[:space:]]*COMMAND=herdr' "$CLOD"
+            The status should be success
+        End
+    End
+
+    Describe 'guest/configure.sh'
+        CONFIGURE="${SHELLSPEC_PROJECT_ROOT}/guest/configure.sh"
+
+        # Without an installed integration herdr falls back to heuristic
+        # detection, and the working/blocked/done sidebar becomes decorative.
+        It 'installs herdr integrations for the preinstalled agents'
+            When call grep -qE 'herdr integration install' "$CONFIGURE"
+            The status should be success
+        End
+    End
+End


### PR DESCRIPTION
Adds support for `herdr` which I find more useful than lots of terminal windows..  This PR is stacked on top of the other PR I submitted about the Brewfile internal support - merge than one first if you like it, then the diff should be clean, otherwise I can rework this one to use the original guest install if required.

